### PR TITLE
Update:初回ログイン後の処理

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -8,7 +8,7 @@ class OauthsController < ApplicationController
   def callback
     provider = "line"
     if @user = login_from(provider)
-      redirect_to profile_path, notice: "Logged in from #{provider.titleize}!"
+      redirect_to user_path(@user), notice: "Logged in from #{provider.titleize}!"
     else
       begin
         @user = create_from(provider)

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,12 +1,20 @@
 class StaticPagesController < ApplicationController
   skip_before_action :require_login, only: [:top]
-  before_action :set_user, only: [:first_login]
-  before_action :first_login?, only: [:first_login]
+  before_action :set_user, only: [:first_login, :update]
+  before_action :first_login?, only: [:first_login, :update]
 
   def top
   end
 
   def first_login
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to user_path(@user)
+    else
+      render 'first_login'
+    end
   end
 
   private
@@ -17,7 +25,11 @@ class StaticPagesController < ApplicationController
 
   def first_login?
     if !@user.first_login
-      redirect_to profile_path
+      redirect_to user_path(@user)
     end
+  end
+
+  def user_params
+    params.require(:user).permit(:username, :comment, :first_login)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,4 @@
-class ProfilesController < ApplicationController
+class UsersController < ApplicationController
   before_action :set_user, only: [:edit, :update, :show]
 
   def edit

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -1,2 +1,0 @@
-module ProfilesHelper
-end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,6 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
+
+  validates :username, presence: true
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,2 +1,0 @@
-<h1>Profiles#edit</h1>
-<p>Find me in app/views/profiles/edit.html.erb</p>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,7 +1,0 @@
-<h1>Profiles#show</h1>
-<p>Find me in app/views/profiles/show.html.erb</p>
-<ul>
-  <li><%= @user.username %>
-  <li><%= @user.role %>
-  <li><%= @user.image %>
-</ul>

--- a/app/views/profiles/update.html.erb
+++ b/app/views/profiles/update.html.erb
@@ -1,2 +1,0 @@
-<h1>Profiles#update</h1>
-<p>Find me in app/views/profiles/update.html.erb</p>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -12,7 +12,7 @@
   <div class="dropdown dropdown-end">
     <div class="flex-none md:hidden">
       <button class="btn btn-square btn-ghost">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"></path></svg>
+       ･･･ 
       </button>
       <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-32">
         <li><a>トップページ</a></li>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,14 +7,27 @@
       <li><a>コミュニティ</a></li>
       <li><a>グループ</a></li>
     </ul>
-    <a class="btn btn-secondary">記録</a>
-  </div>
-  <div class="dropdown dropdown-end">
+    <a class="btn btn-accent">記録</a>
+    <div class="dropdown dropdown-end">
+      <div class="flex-none">
+        <label tabindex="0" class="btn btn-ghost btn-circle avatar mx-4">
+          <div class="max-h-full rounded-full">
+            <%= image_tag current_user.image %>
+          </div>
+        </label>
+        <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-32">
+          <li><a>マイページ</a></li>
+        </ul>
+      </div>
+    </div>
     <div class="flex-none md:hidden">
-      <button class="btn btn-square btn-ghost">
-        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="inline-block w-5 h-5 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h.01M12 12h.01M19 12h.01M6 12a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0zm7 0a1 1 0 11-2 0 1 1 0 012 0z"></path></svg>
-      </button>
+      <label tabindex="0" class="btn btn-ghost btn-circle avatar mx-2">
+        <div class="max-h-full rounded-full">
+          <%= image_tag current_user.image %>
+        </div>
+      </label>
       <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-32">
+        <li><a>マイページ</a></li>
         <li><a>コミュニティ</a></li>
         <li><a>グループ</a></li>
       </ul>

--- a/app/views/static_pages/first_login.html.erb
+++ b/app/views/static_pages/first_login.html.erb
@@ -1,5 +1,42 @@
-<h1>StaticPages#first_login</h1>
-<p>Find me in app/views/static_pages/first_login.html.erb</p>
-<div>
-  <%= link_to "Top Page", root_path %>
+<div class="mx-auto max-w-4xl overflow-hidden bg-base-100 px-8 py-12 sm:px-24 sm:py-24">
+  <div class="card mx-8 max-w-full rounded-xl bg-white shadow-xl">
+    <div class="card-body mx-auto items-center text-center">
+      <h2 class="card-title">プロフィール&休肝日設定</h2>
+      <p>プロフィールと休肝日を登録しよう！</p>
+      <%= form_with(model: @user, url: first_login_path, local: true) do |f| %>
+        <div class="form-control w-full max-w-full py-2">
+          <%= f.label :username, class: "label" %>
+          <%= f.text_field :username, class: "input input-bordered w-full max-w-xs" %>
+        </div>
+        <div class="form-control">
+          <label class="label">
+            <span class="label-text">What is your name?</span>
+          </label>
+          <div class="join join-vertical lg:join-horizontal">
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Monday" />
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Tuesday" />
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Wednesday" />
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Thursday" />
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Friday" />
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Saturday" />
+            <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Sunday" />
+          </div>
+        </div>
+        <div class="form-control py-2">
+          <%= f.label :comment, class: "label" %>
+          <%= f.text_area :comment, class:"h-18 textarea textarea-bordered" %>
+        </div>
+        <div class="form-control py-2">
+          <label class="label cursor-pointer">
+            <span class="label-text">Remember me</span> 
+            <input type="checkbox" class="toggle" />
+          </label>
+        </div>
+        <%= f.hidden_field :first_login, value: false %>
+        <div class="card-actions justify-end">
+          <%= f.submit "登録", class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,34 @@
+<%= form_with(model: @user, url: first_login_path, local: true) do |f| %>
+  <div class="form-control w-full max-w-full py-2">
+    <%= f.label :username, class: "label" %>
+    <%= f.text_field :username, class: "input input-bordered w-full max-w-xs" %>
+  </div>
+  <div class="form-control">
+    <label class="label">
+      <span class="label-text">What is your name?</span>
+    </label>
+    <div class="join join-vertical lg:join-horizontal">
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Monday" />
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Tuesday" />
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Wednesday" />
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Thursday" />
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Friday" />
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Saturday" />
+      <input class="btn btn-xs btn-outline join-item" type="checkbox" name="options" aria-label="Sunday" />
+    </div>
+  </div>
+  <div class="form-control py-2">
+    <%= f.label :comment, class: "label" %>
+    <%= f.text_area :comment, class:"h-18 textarea textarea-bordered" %>
+  </div>
+  <div class="form-control py-2">
+    <label class="label cursor-pointer">
+      <span class="label-text">Remember me</span> 
+      <input type="checkbox" class="toggle" />
+    </label>
+  </div>
+  <div class="card-actions justify-end">
+    <%= f.submit "登録", class: "btn btn-primary" %>
+  </div>
+<% end %>
+

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#edit</h1>
+<p>Find me in app/views/users/edit.html.erb</p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,7 @@
+<h1>Users#show</h1>
+<p>Find me in app/views/users/show.html.erb</p>
+<ul>
+  <li><%= @user.username %>
+  <li><%= @user.role %>
+  <li><%= image_tag @user.image %>
+</ul>

--- a/app/views/users/update.html.erb
+++ b/app/views/users/update.html.erb
@@ -1,0 +1,2 @@
+<h1>Users#update</h1>
+<p>Find me in app/views/users/update.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,9 @@
 Rails.application.routes.draw do
   root "static_pages#top"
   get 'first_login', to: 'static_pages#first_login'
-  resource :profile, only: [:edit, :update, :show]
+  patch 'first_login', to: 'static_pages#update'
+  put 'first_login', to: 'static_pages#update'
+  resources :users, only: [:edit, :update, :show]
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,18 +1,18 @@
 require "test_helper"
 
-class ProfilesControllerTest < ActionDispatch::IntegrationTest
+class UsersControllerTest < ActionDispatch::IntegrationTest
   test "should get edit" do
-    get profiles_edit_url
+    get users_edit_url
     assert_response :success
   end
 
   test "should get update" do
-    get profiles_update_url
+    get users_update_url
     assert_response :success
   end
 
   test "should get show" do
-    get profiles_show_url
+    get users_show_url
     assert_response :success
   end
 end


### PR DESCRIPTION
## 概要
初回ログインページの作成とUserテーブルに関わる初回ログイン時のプロフィール登録機能を追加しました。
また、今後のコミュニティ機能を見越して、ユーザー詳細画面を見れるようにProfileモデルからUserモデルに変更して、ルーティングについてもresoucesとしました。

## 確認方法
初回のLINEログインのコールバック後、初回ログインページに遷移することを確認してください。
初回ログインページにて更新した`username`及び`comment`が反映されていることを確認してください。
初回ログインページには2回目のログイン以降はアクセスできないことを確認してください。

## 影響範囲
Profilesコントローラを`destroy`したので、周辺のビューファイルやコントローラファイル、ルーティングは削除しています。

## コメント
休肝日の登録及びリマインダーの登録については後日実装します。