### PR TITLE
Add:月間の休肝日達成率と総アルコール摂取量を表示

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,47 @@ class User < ApplicationRecord
   validates :username, presence: true
   validates :comment, length: { maximum: 256 }
   validates :non_drinking_days, presence: true
+
+  def monthly_no_drink_day_records
+    self.drink_records.no_drink.where(start_time: Date.today.all_month).count
+  end
+
+  def monthly_non_drinking_days
+    # 当月の初日から当日までの日付を取得
+    days = Date.today.beginning_of_month..Date.today
+    # non_drinking_daysの配列に当月の日付が含まれているかどうかを判定
+    days.select { |day| self.non_drinking_days.include?(day.wday) }.count
+  end
+
+  def monthly_no_drink_achievement
+    return 0 if self.monthly_non_drinking_days == 0
+    (self.monthly_no_drink_day_records.to_f / self.monthly_non_drinking_days.to_f * 100).round(1)
+  end
+
+  def monthly_total_amount_alcohol
+    total_amount_alcohol = 0
+    self.drink_records.drink.where(start_time: Date.today.all_month).each do |drink_record|
+      amount_alcohol = drink_record.drink_volume.to_f * (drink_record.alcohol_percentage.to_f * 0.01) * 0.8
+      total_amount_alcohol += amount_alcohol
+    end
+    return total_amount_alcohol.round(1)
+  end
+
+  def last_manth_total_amount_alcohol
+    total_amount_alcohol = 0
+    self.drink_records.drink.where(start_time: Date.today.last_month.all_month).each do |drink_record|
+      amount_alcohol = drink_record.drink_volume.to_f * (drink_record.alcohol_percentage.to_f * 0.01) * 0.8
+      total_amount_alcohol += amount_alcohol
+    end
+    return total_amount_alcohol.round(1)
+  end
+
+  def compare_rate_last_manth_total_amount_alcohol
+    return 0 if self.last_manth_total_amount_alcohol == 0
+    (self.monthly_total_amount_alcohol.to_f / self.last_manth_total_amount_alcohol.to_f * 100).round(1)
+  end
+
+  def compare_amount_last_manth_total_amount_alcohol
+    (self.monthly_total_amount_alcohol.to_f - self.last_manth_total_amount_alcohol.to_f).round(1)
+  end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -37,14 +37,20 @@
         <div class="stats stats-vertical my-2 w-full bg-accent-content shadow sm:stats-horizontal md:stats-vertical">
           <div class="stat">
             <div class="stat-title"><%= t '.no_alcohol_day_achievement' %></div>
-            <div class="stat-value">31%</div>
-            <div class="stat-desc">Jan 1st - Feb 1st</div>
+            <div class="stat-value"><%= @user.monthly_no_drink_achievement %>%</div>
+            <div class="stat-desc"><%= Date.today.beginning_of_month %> - <%= Date.today%></div>
           </div>
 
           <div class="stat">
             <div class="stat-title"><%= t '.alcohol_intake' %></div>
-            <div class="stat-value">4,200</div>
-            <div class="stat-desc">↗︎ 400 (22%)</div>
+            <div class="stat-value"><%= @user.monthly_total_amount_alcohol %>ml</div>
+            <% if @user.compare_amount_last_manth_total_amount_alcohol > 0 %>
+              <div class="stat-desc">↗︎ <%= @user.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+            <% elsif @user.compare_amount_last_manth_total_amount_alcohol < 0 %>
+              <div class="stat-desc">↘︎ <%= @user.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+            <% else %>
+              <div class="stat-desc">- <%= @user.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,8 +29,8 @@ ja:
       title: 'マイページ'
       no_alcohol_day: '休肝日'
       create_group: 'グループを作成'
-      no_alcohol_day_achievement: '休肝日達成率（直近30日間）'
-      alcohol_intake: '総アルコール摂取量（直近30日間）'
+      no_alcohol_day_achievement: '休肝日達成率（今月）'
+      alcohol_intake: '総アルコール摂取量（今月）'
   drink_records:
     new:
       title: '休肝日&飲酒記録'


### PR DESCRIPTION
## 概要
* プロフィールページにおいて月間（月初日から当日まで）の休肝日達成率と総アルコール摂取量を表示できるように実装しました。
## 確認方法
* 休肝日達成率は、（今日までに「休肝日」として登録した日数）/（今日までのあらかじめ休肝日として登録してある曜日の日数）として反映している。
* 総アルコール摂取量は、月初日から当日までのアルコール摂取量の合計が反映されている。
* 総アルコール摂取量には前月との比較が表示されている。