### PR TITLE
Add:記録編集・削除機能の追加

### DIFF
--- a/app/controllers/drink_records_controller.rb
+++ b/app/controllers/drink_records_controller.rb
@@ -31,10 +31,10 @@ class DrinkRecordsController < ApplicationController
   end
 
   def update
-    @drink_record = current_user.drink_records.assign_attributes(drink_record_params)
+    @drink_record.assign_attributes(drink_record_params)
     if @drink_record.can_record_date?
       if @drink_record.save
-        redirect_to edit_profile_path
+        redirect_to profile_path
       else
         render :edit, status: :unprocessable_entity
       end

--- a/app/controllers/drink_records_controller.rb
+++ b/app/controllers/drink_records_controller.rb
@@ -13,7 +13,7 @@ class DrinkRecordsController < ApplicationController
     @drink_record = current_user.drink_records.new(drink_record_params)
     if @drink_record.can_record_date?
       if @drink_record.save
-        redirect_to profile_path
+        redirect_to profile_path, success: t('defaults.create_success')
       else
         flash.now[:error] = t '.error'
         render :new, status: :unprocessable_entity
@@ -45,6 +45,8 @@ class DrinkRecordsController < ApplicationController
   end
 
   def destroy
+    @drink_record.destroy!
+    redirect_to profile_path, success: t('defaults.delete_success')
   end
 
   private

--- a/app/views/drink_records/_form.html.erb
+++ b/app/views/drink_records/_form.html.erb
@@ -3,13 +3,15 @@
     <%= f.radio_button :record_type, "no_drink", class: "btn btn-primary btn-outline join-item m-4 px-12 js-check", "aria-label": :"休肝日", id: "hide" %>
     <%= f.radio_button :record_type, "drink", class: "btn btn-secondary btn-outline join-item m-4 px-12 js-check", "aria-label": :"飲酒日" , id: "disp" %>
   </div>
+  <div class="m-8">
+    <div class="form-control mb-4 flex w-full flex-row items-center">
+      <%= f.label :start_time, class: "label mr-8 w-44" %>
+      <%= f.date_field :start_time, class: "input input-bordered w-full max-w-xs", value: Date.today.strftime("%Y-%m-%d") %>
+    </div>
+  </div>
   <div id="drink-details">
     <div class="mx-8 border-b-2 font-semibold"><%= t 'defaults.detail' %></div>
     <div class="m-8">
-      <div class="form-control mb-4 flex w-full flex-row items-center">
-        <%= f.label :start_time, class: "label mr-8 w-44" %>
-        <%= f.date_field :start_time, class: "input input-bordered w-full max-w-xs", value: Date.today.strftime("%Y-%m-%d") %>
-      </div>
       <div class="form-control mb-4 flex w-full flex-row items-center">
         <%= f.label :drink_type, class: "label mr-8 w-44" %>
         <%= f.text_field :drink_type, class: "input input-bordered w-full max-w-xs" %>
@@ -29,7 +31,7 @@
         </div>
       </div>
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44 font-semibold">アルコール摂取量</label>
+        <label class="label mr-8 w-44 font-semibold"><%= t 'defaults.amount_of_alcohol' %></label>
         <div class="flex flex-row items-center">
           <div id="alcohol_intake", class="font-semibold">
             <%= alcohol_caluculate(drink_record.drink_volume, drink_record.alcohol_percentage) %>

--- a/app/views/drink_records/show.html.erb
+++ b/app/views/drink_records/show.html.erb
@@ -1,45 +1,51 @@
 <div class="mx-auto max-w-4xl overflow-hidden bg-base-100 py-4 sm:px-24 sm:py-24">
   <div class="card mx-8 max-w-full rounded-xl bg-white shadow-xl">
-    <div class="mx-auto items-center text-center py-6">
-      <h2 class="card-title text-4xl">今日はどっち？</h2>
+    <div class="card-body mx-auto items-center py-6 text-center">
+      <h2 class="card-title text-4xl"><%= t '.title' %></h2>
     </div>
     <div class="flex flex-col items-center justify-evenly md:flex-row md:content-evenly">
-      <input class="btn btn-primary btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]" aria-label="休肝日" />
-      <input class="btn btn-secondary btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]" aria-label="飲酒日" />
+      <% if @drink_record.no_drink? %>
+        <div class="btn btn-primary btn-active btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]"><%= t 'defaults.no_alcohol_day' %></div>
+        <div class="btn btn-secondary btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]"><%= t 'defaults.alcohol_day' %></div>
+      <% else %>
+        <div class="btn btn-primary btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]"><%= t 'defaults.no_alcohol_day' %></div>
+        <div class="btn btn-secondary btn-active btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]"><%= t 'defaults.alcohol_day' %></div>
+      <% end %>
     </div>
     <div class="mx-8 border-b-2 font-semibold">詳細</div>
     <div class="m-8">
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44">記録日</label>
-        <input type="text" placeholder="Type here" class="input input-bordered w-full max-w-xs" />
+        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:start_time) %></label>
+        <div class="font-semibold"><%= @drink_record.start_time.strftime("%Y年 %m月 %d日(%a)") %></div>
       </div>
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44">お酒の種類</label>
-        <input type="text" placeholder="Type here" class="input input-bordered w-full max-w-xs" />
+        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:drink_type) %></label>
+        <div class="font-semibold"><%= @drink_record.drink_type %></div>
       </div>
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44">お酒の量</label>
+        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:drink_volume) %></label>
         <div class="flex flex-row items-center">
-          <input type="number" placeholder="Type here" class="input input-bordered w-full max-w-xs" />
+          <div class="font-semibold"><%= @drink_record.drink_volume %></div>
           <div class="ml-4 font-semibold">ml</div>
         </div>
       </div>
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44">アルコール度数</label>
+        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:alcohol_percentage) %></label>
         <div class="flex flex-row items-center">
-          <input type="number" placeholder="Type here" class="input input-bordered w-full max-w-xs" />
-          <div class="ml-4 font-semibold">ml</div>
+          <div class="font-semibold"><%= @drink_record.alcohol_percentage %></div>
+          <div class="ml-4 font-semibold">%</div>
         </div>
       </div>
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44 font-semibold">アルコール摂取量</label>
+        <label class="label mr-8 w-44 font-semibold"><%= t 'defaults.amount_of_alcohol' %></label>
         <div class="flex flex-row items-center">
-          <div class="font-semibold">20</div>
+          <div class="font-semibold"><%= alcohol_caluculate(@drink_record.drink_volume, @drink_record.alcohol_percentage) %></div>
           <div class="ml-4 font-semibold">ml</div>
         </div>
       </div>
       <div class="card-actions justify-end">
-        <div class="btn btn-primary">登録</div>
+        <%= link_to t('defaults.edit'), edit_drink_record_path, class: "btn btn-primary" %>
+        <%= link_to t('defaults.delete'), drink_record_path, class: "btn btn-accent", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") } %>
       </div>
     </div>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -64,9 +64,9 @@
           <div><%= date.day %></div>
           <% drink_record.each do |record| %>
             <% if record.no_drink? %>
-              <div class="badge badge-xs badge-primary md:badge-sm lg:badge-md"><%= record.record_type_i18n %></div>
+              <%= link_to record.record_type_i18n, drink_record_path(record), class:"badge badge-xs badge-primary md:badge-sm lg:badge-md", data: { turbo: false } %>
             <% elsif record.drink? %>
-              <div class="badge badge-xs badge-secondary md:badge-sm lg:badge-md"><%= record.record_type_i18n %></div>
+              <%= link_to record.record_type_i18n, drink_record_path(record), class:"badge badge-xs badge-secondary md:badge-sm lg:badge-md", data: { turbo: false } %>
             <% end %>
           <% end %>
         <% end %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -10,9 +10,15 @@ ja:
     privacy_policy: 'プライバシーポリシー'
     register: '登録'
     detail: '詳細'
+    edit: '編集'
+    delete: '削除'
     no_alcohol_day: '休肝日'
     alcohol_day: '飲酒日'
     record_date_error: '未来の日付で記録はできません'
+    amount_of_alcohol: 'アルコール摂取量'
+    delete_confirm: '削除しますか？'
+    delete_success: '記録を削除しました'
+    create_success: '記録を登録しました'
   static_pages:
     top:
       title: 'トップページ'
@@ -39,6 +45,8 @@ ja:
       title: '休肝日&飲酒記録編集'
     create:
       error: '休肝日または飲酒記録の登録に失敗しました'
+    show:
+      title: '記録詳細'
   simple_calendar:
     previous: "<<"
     next: ">>"


### PR DESCRIPTION
## 概要
* 休肝日&飲酒記録の詳細画面を作成しました。
* 休肝日&飲酒記録の編集・削除機能を実装しました。
## 確認方法
* プロフィールページのカレンダーの「休肝日」または「飲酒日」をクリックすると、休肝日または飲酒記録の詳細ページに遷移することを確認してください。
* 詳細ページの「編集」ボタンから記録の編集ができることを確認してください。
* 詳細ページの「削除」ボタンから記録の削除ができることを確認してください。
## コメント
* 同じ日に投稿できないようにバリデーションを設定する必要がある
* 編集時に記録日が当日になってしまっているため、編集しづらい･･･修正が必要