### PR TITLE
Add:グループの編集・削除機能追加

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -10,23 +10,30 @@ class GroupsController < ApplicationController
     # binding.pry
     if @group.save
       @group.save_group_member(current_user)
-      redirect_to groups_path, success: t('.success')
+      redirect_to group_path, success: t('.success')
     else
       flash.now[:error] = t('.error')
       render :new, status: :unprocessable_entity
     end
   end
 
-  def show
-  end
+  def show; end
 
-  def edit
-  end
+  def edit; end
 
   def update
+    @group.assign_attributes(group_params)
+    if @group.save
+      redirect_to group_path, success: t('.success')
+    else
+      flash.now[:error] = t('.error')
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   def destroy
+    @group.destroy!
+    redirect_to profile_path, success: t('.success')
   end
 
   private

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,5 @@
 class Group < ApplicationRecord
-  has_many :user_groups
+  has_many :user_groups, dependent: :destroy
   has_many :users, through: :user_groups
 
   validates :name, presence: true

--- a/app/views/groups/edit.html.erb
+++ b/app/views/groups/edit.html.erb
@@ -1,2 +1,8 @@
-<h1>Groups#edit</h1>
-<p>Find me in app/views/groups/edit.html.erb</p>
+<div class="mx-auto max-w-4xl overflow-hidden bg-base-100 py-4 sm:px-24 sm:py-24 flex-auto">
+  <div class="card mx-8 max-w-full rounded-xl bg-white shadow-xl">
+    <div class="card-body mx-auto items-center py-6 text-center">
+      <h2 class="card-title"><%= t '.title' %></h2>
+      <%= render partial: 'groups/form', locals: { group: @group } %>
+    </div>
+  </div>
+</div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -6,6 +6,7 @@
           <h2 class="title-font text-2xl font-semibold text-neutral-900 mb-4"><%= @group.name %></h2>
           <div class="text-right">
             <%= link_to (t '.edit'), edit_group_path, class:"link text-xs" %>
+            <%= link_to (t '.delete'), group_path, class:"link text-xs", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") }  %>
           </div>
         </div>
         <div class="mb-4">

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -65,6 +65,16 @@ ja:
       admin: '管理者'
       member: 'メンバー'
       invite: 'メンバーを招待'
+    edit:
+      title: 'グループ編集'
+      success: 'グループを更新しました'
+      error: 'グループの更新に失敗しました'
+    update:
+      success: 'グループを更新しました'
+      error: 'グループの更新に失敗しました'
+    destroy:
+      success: 'グループを削除しました'
+      error: 'グループの削除に失敗しました'
   simple_calendar:
     previous: "<<"
     next: ">>"


### PR DESCRIPTION
## 概要
* グループの編集機能と削除機能を追加しました。
## 確認方法
* グループ詳細画面の編集リンクから編集画面に遷移することを確認してください。
* グループ詳細画面の削除リンクからグループを削除できることを確認してください。
## コメント
* 後々、グループ編集においてユーザの登録削除ができるようにする予定。