### PR TITLE
Add:招待機能の追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,10 +2,15 @@ class ApplicationController < ActionController::Base
   add_flash_types :success, :warning, :error, :info
 
   before_action :require_login
+  before_action :require_general
 
   private
 
   def not_authenticated
       redirect_to root_path, error: "Please login first"
+  end
+
+  def require_general
+    redirect_to profile_path, warning: t('defaults.access_denied') unless current_user.general?
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -12,7 +12,7 @@ class GroupsController < ApplicationController
     # binding.pry
     if @group.save
       @group.save_group_member(current_user)
-      redirect_to profile_path, success: t('.success')
+      redirect_to group_path(@group), success: t('.success')
     else
       flash.now[:error] = t('.error')
       render :new, status: :unprocessable_entity
@@ -26,7 +26,7 @@ class GroupsController < ApplicationController
   def update
     @group.assign_attributes(group_params)
     if @group.save
-      redirect_to profile_path, success: t('.success')
+      redirect_to group_path(@group), success: t('.success')
     else
       flash.now[:error] = t('.error')
       render :edit, status: :unprocessable_entity

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: %i[show edit update destroy]
+  skip_before_action :require_general, only: %i[show]
 
   def new
     @group = current_user.groups.new
@@ -7,6 +8,7 @@ class GroupsController < ApplicationController
 
   def create
     @group = current_user.groups.new(group_params)
+    @group.set_invite_token
     # binding.pry
     if @group.save
       @group.save_group_member(current_user)

--- a/app/controllers/invitees/invitation_controller.rb
+++ b/app/controllers/invitees/invitation_controller.rb
@@ -1,0 +1,34 @@
+class Invitees::InvitationController < ApplicationController
+  skip_before_action :require_login, only: %i[new create]
+  skip_before_action :require_general, only: %i[new first_login update]
+  before_action :group_invite_token, only: %i[new]
+
+  def new; end
+
+  def first_login; end
+
+  def update
+    if @user.update(user_params_with_days)
+      redirect_to group_path(@user.groups.first), success: 'プロフィールを登録しました'
+    else
+      flash.now[:error] = 'プロフィールの登録に失敗しました'
+      render 'first_login'
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def first_login?
+    if !@user.first_login
+      redirect_to group_path(@user.group.first), warning: '既にプロフィールは登録済みです'
+    end
+  end
+
+  def group_invite_token
+    @group = Group.find_by(invite_token: params[:invite_token])
+  end
+end

--- a/app/controllers/invitees/oauths_controller.rb
+++ b/app/controllers/invitees/oauths_controller.rb
@@ -1,0 +1,28 @@
+class Invitees::OauthsController < ApplicationController
+  skip_before_action :require_login
+  skip_before_action :require_general
+
+  def oauth
+    session[:invite_token] = params[:invite_token]
+    login_at(params[:provider])
+  end
+
+  def callback
+    provider = params[:provider]
+    if @user = login_from(provider)
+      redirect_to group_path(@user.groups.first), success: "Logged in from #{provider.titleize}!"
+    else
+      begin
+        @user = create_from(provider)
+        @user.role = :invitee
+        @group = Group.find_by(invite_token: session[:invite_token])
+        @group.save_group_member(@user)
+        reset_session
+        auto_login(@user)
+        redirect_to invitees_invitation_first_login_path, success: "Logged in from #{provider.titleize}!"
+      rescue
+        redirect_to root_path, error: "Failed to login from #{provider.titleize}!"
+      end
+    end
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,11 +3,9 @@ class StaticPagesController < ApplicationController
   before_action :set_user, only: [:first_login, :update]
   before_action :first_login?, only: [:first_login, :update]
 
-  def top
-  end
+  def top; end
 
-  def first_login
-  end
+  def first_login; end
 
   def update
     user_params_with_days = user_params

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,5 +1,6 @@
 class StaticPagesController < ApplicationController
   skip_before_action :require_login, only: [:top]
+  skip_before_action :require_general, only: [:top]
   before_action :set_user, only: [:first_login, :update]
   before_action :first_login?, only: [:first_login, :update]
 

--- a/app/helpers/invitees/invitation_helper.rb
+++ b/app/helpers/invitees/invitation_helper.rb
@@ -1,0 +1,2 @@
+module Invitees::InvitationHelper
+end

--- a/app/helpers/invitees/oauths_helper.rb
+++ b/app/helpers/invitees/oauths_helper.rb
@@ -1,0 +1,2 @@
+module Invitees::OauthsHelper
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,6 +4,7 @@ class Group < ApplicationRecord
 
   validates :name, presence: true
   validates :group_admin_id, presence: true
+  validates :invite_token, presence: true, uniqueness: true
 
   def save_group_member(user)
     self.users << user
@@ -11,5 +12,9 @@ class Group < ApplicationRecord
 
   def group_admin
     User.find(self.group_admin_id)
+  end
+
+  def set_invite_token
+    self.invite_token = SecureRandom.hex(16)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,8 @@ class User < ApplicationRecord
   validates :comment, length: { maximum: 256 }
   validates :non_drinking_days, presence: true
 
+  enum role: { general: 0, invitee: 10, admin: 20 }
+
   def monthly_no_drink_day_records
     self.drink_records.no_drink.where(start_time: Date.today.all_month).count
   end

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,57 +1,59 @@
 <div class="flex flex-col p-4 md:flex-row md:p-8 flex-auto">
-  <div class="card rounded-box flex-grow place-items-center bg-white shadow-xl md:w-1/3">
-    <div class="w-full p-4">
-      <div class="h-full flex-row items-center justify-center text-left md:justify-start md:text-left">
-        <div class="flex-grow py-4 pl-4">
-          <h2 class="title-font text-2xl font-semibold text-neutral-900 mb-4"><%= @group.name %></h2>
-          <div class="text-right">
-            <%= link_to (t '.edit'), edit_group_path, class:"link text-xs" %>
-            <%= link_to (t '.delete'), group_path, class:"link text-xs", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") }  %>
-          </div>
-        </div>
-        <div class="mb-4">
-          <h2 class="title-font text-lg font-semibold text-neutral-900"><%= t '.admin' %></h2>
-          <div class="flex flex-row items-center p-4 text-left md:text-left border border-primary rounded-lg">
-            <div class="avatar">
-              <div class="h-24 w-24 rounded-full">
-                <%= image_tag @group.group_admin.image %>
-              </div>
-            </div>
-            <div class="pl-6">
-              <div>
-                <h2 class="title-font text-xl font-semibold text-neutral-900"><%= @group.group_admin.username %></h2>
-                <p><%= t '.no_alcohol_day' %></p>
-                <% @group.group_admin.non_drinking_days.each do |index| %>
-                  <div class="badge badge-primary"><%= I18n.t('date.day_names')[index] %></div>
-                <% end %>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="w-full">
-          <h2 class="title-font text-lg font-semibold text-neutral-900"><%= t 'defaults.group' %></h2>
-          <% if @group.users.present? %>
-            <% @group.users.each do |user| %>
-              <div class="flex flex-row items-center p-4 text-left md:text-left border border-primary rounded-lg">
-                <div class="avatar">
-                  <div class="h-24 w-24 rounded-full">
-                    <%= image_tag user.image %>
-                  </div>
+  <div class="flex flex-col md:w-1/3">
+    <div class="card p-4 bg-primary bg-opacity-50">
+      <h2 class="title-font text-2xl font-semibold text-neutral-900"><%= @group.name %></h2>
+      <div class="text-right">
+        <%= link_to (t '.edit'), edit_group_path(@group), class:"btn btn-info btn-sm" %>
+        <%= link_to (t '.delete'), group_path(@group), class:"btn btn-error btn-sm", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") }  %>
+      </div>
+    </div>
+    <div class="card rounded-box flex-grow place-items-center bg-white shadow-xl mt-4">
+      <div class="w-full p-4">
+        <div class="h-full flex-row items-center justify-center text-left md:justify-start md:text-left">
+          <div class="mb-4">
+            <h2 class="title-font text-lg font-semibold text-neutral-900"><%= t '.admin' %></h2>
+            <div class="flex flex-row items-center p-4 text-left md:text-left border border-primary rounded-lg">
+              <div class="avatar">
+                <div class="h-24 w-24 rounded-full">
+                  <%= image_tag @group.group_admin.image %>
                 </div>
-                <div class="pl-6">
-                  <h2 class="title-font text-xl font-semibold text-neutral-900"><%= user.username %></h2>
-                </div> 
+              </div>
+              <div class="pl-6">
+                <div>
+                  <h2 class="title-font text-xl font-semibold text-neutral-900"><%= @group.group_admin.username %></h2>
+                  <p><%= t '.no_alcohol_day' %></p>
+                  <% @group.group_admin.non_drinking_days.each do |index| %>
+                    <div class="badge badge-primary"><%= I18n.t('date.day_names')[index] %></div>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          </div>
+  
+          <div class="w-full">
+            <h2 class="title-font text-lg font-semibold text-neutral-900"><%= t '.member' %></h2>
+            <% if @group.users.present? %>
+              <% @group.users.each do |user| %>
+                <div class="flex flex-row items-center p-4 text-left md:text-left border border-primary rounded-lg">
+                  <div class="avatar">
+                    <div class="h-24 w-24 rounded-full">
+                      <%= image_tag user.image %>
+                    </div>
+                  </div>
+                  <div class="pl-6">
+                    <h2 class="title-font text-xl font-semibold text-neutral-900"><%= user.username %></h2>
+                  </div> 
+                </div>
+              <% end %>
+            <% else %>
+              <div class="btn-neutral-100 btn btn-active w-full">
+                <%= t '.no_group' %>
               </div>
             <% end %>
-          <% else %>
-            <div class="btn-neutral-100 btn btn-active w-full">
-              <%= t '.no_group' %>
+            <div class="text-left py-4">
+              <p class="font-semibold"><%= t '.invite' %></p>
+              <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
             </div>
-          <% end %>
-          <div class="text-left py-4">
-            <p class="font-semibold"><%= t '.invite' %></p>
-            <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
           </div>
         </div>
       </div>
@@ -59,49 +61,48 @@
   </div>
   <div class="divider md:divider-horizontal"></div>
   <div class="flex flex-col md:w-2/3">
-  <div class="card rounded-box flex-col bg-white shadow-xl max-w-full">
-    <div class="flex w-full flex-col p-4">
-      <div class="card rounded-box grid">
-        <h2 class="text-xl font-semibold text-center"><%= t 'defaults.record' %></h2>
-        <%= week_calendar(number_of_weeks: 2, events: @drink_record) do |date, drink_record| %>
-          <div><%= date.day %></div>
-          <% drink_record.each do |record| %>
-            <% if record.no_drink? %>
-              <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-primary md:btn-sm lg:btn-md", data: { turbo: false } %>
-            <% elsif record.drink? %>
-              <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-secondary md:btn-sm lg:btn-md", data: { turbo: false } %>
+    <div class="card rounded-box flex-col bg-white shadow-xl max-w-full">
+      <div class="flex w-full flex-col p-4">
+        <div class="card rounded-box grid">
+          <h2 class="text-xl font-semibold text-center"><%= t 'defaults.record' %></h2>
+          <%= week_calendar(number_of_weeks: 2, events: @drink_record) do |date, drink_record| %>
+            <div><%= date.day %></div>
+            <% drink_record.each do |record| %>
+              <% if record.no_drink? %>
+                <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-primary md:btn-sm lg:btn-md", data: { turbo: false } %>
+              <% elsif record.drink? %>
+                <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-secondary md:btn-sm lg:btn-md", data: { turbo: false } %>
+              <% end %>
             <% end %>
           <% end %>
-        <% end %>
-        <p class="text-xl font-semibold"><%= t 'defaults.record' %></p>
-        <div class="stats stats-vertical my-2 w-full bg-accent-content shadow md:stats-horizontal md:grid-cols-2">
-          <div class="stat">
-            <div class="stat-title"><%= t '.no_alcohol_day_achievement' %></div>
-            <div class="stat-value"><%= @group.group_admin.monthly_no_drink_achievement %>%</div>
-            <div class="stat-desc"><%= Date.today.beginning_of_month %> - <%= Date.today%></div>
-          </div>
-
-          <div class="stat">
-            <div class="stat-title"><%= t '.alcohol_intake' %></div>
-            <div class="stat-value"><%= @group.group_admin.monthly_total_amount_alcohol %>ml</div>
-            <% if @group.group_admin.compare_amount_last_manth_total_amount_alcohol > 0 %>
-              <div class="stat-desc">↗︎ <%= @group.group_admin.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @group.group_admin.compare_rate_last_manth_total_amount_alcohol %>%)</div>
-            <% elsif @group.group_admin.compare_amount_last_manth_total_amount_alcohol < 0 %>
-              <div class="stat-desc">↘︎ <%= @group.group_admin.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @group.group_admin.compare_rate_last_manth_total_amount_alcohol %>%)</div>
-            <% else %>
-              <div class="stat-desc">- <%= @group.group_admin.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @group.group_admin.compare_rate_last_manth_total_amount_alcohol %>%)</div>
-            <% end %>
+          <p class="text-xl font-semibold"><%= t 'defaults.record' %></p>
+          <div class="stats stats-vertical my-2 w-full bg-accent-content shadow md:stats-horizontal md:grid-cols-2">
+            <div class="stat">
+              <div class="stat-title"><%= t '.no_alcohol_day_achievement' %></div>
+              <div class="stat-value"><%= @group.group_admin.monthly_no_drink_achievement %>%</div>
+              <div class="stat-desc"><%= Date.today.beginning_of_month %> - <%= Date.today%></div>
+            </div>
+            <div class="stat">
+              <div class="stat-title"><%= t '.alcohol_intake' %></div>
+              <div class="stat-value"><%= @group.group_admin.monthly_total_amount_alcohol %>ml</div>
+              <% if @group.group_admin.compare_amount_last_manth_total_amount_alcohol > 0 %>
+                <div class="stat-desc">↗︎ <%= @group.group_admin.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @group.group_admin.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+              <% elsif @group.group_admin.compare_amount_last_manth_total_amount_alcohol < 0 %>
+                <div class="stat-desc">↘︎ <%= @group.group_admin.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @group.group_admin.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+              <% else %>
+                <div class="stat-desc">- <%= @group.group_admin.compare_amount_last_manth_total_amount_alcohol %>ml (<%= @group.group_admin.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+              <% end %>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-  <div class="card rounded-box flex-col bg-white shadow-xl max-w-full my-8">
-    <div class="flex w-full flex-col p-4">
-      <div class="card rounded-box grid">
-        <h2 class="text-xl font-semibold text-center"><%= t 'defaults.record' %></h2>
+    <div class="card rounded-box flex-col bg-white shadow-xl max-w-full my-8">
+      <div class="flex w-full flex-col p-4">
+        <div class="card rounded-box grid">
+          <h2 class="text-xl font-semibold text-center"><%= t 'defaults.record' %></h2>
+        </div>
       </div>
     </div>
-  </div>
   </div>
 </div>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -49,8 +49,9 @@
               <%= t '.no_group' %>
             </div>
           <% end %>
-          <div class="text-right">
-            <%= link_to t('.invite'), new_group_path, class: "link text-xs", data: { turbo: false } %>
+          <div class="text-left py-4">
+            <p class="font-semibold"><%= t '.invite' %></p>
+            <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
           </div>
         </div>
       </div>

--- a/app/views/invitees/invitation/first_login.html.erb
+++ b/app/views/invitees/invitation/first_login.html.erb
@@ -1,0 +1,18 @@
+<div class="mx-auto max-w-4xl overflow-hidden bg-base-100 py-4 sm:px-24 sm:py-24 flex-auto">
+  <div class="card mx-8 max-w-full rounded-xl bg-white shadow-xl">
+    <div class="card-body mx-auto items-center text-center">
+      <h2 class="card-title"><%= t '.form_title' %></h2>
+      <p><%= t '.form_description' %></p>
+      <%= form_with(model: @user, url: invitees_invitation_first_login_path, local: true) do |f| %>
+        <div class="form-control w-full max-w-full py-2">
+          <%= f.label :username, class: "label" %>
+          <%= f.text_field :username, class: "input input-bordered w-full max-w-xs" %>
+        </div>
+        <%= f.hidden_field :first_login, value: false %>
+        <div class="card-actions justify-end">
+          <%= f.submit (t 'defaults.register'), class: "btn btn-primary" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/invitees/invitation/new.html.erb
+++ b/app/views/invitees/invitation/new.html.erb
@@ -2,7 +2,6 @@
   <div class="card mx-8 max-w-full rounded-xl bg-white shadow-xl">
     <div class="card-body mx-auto items-center text-center">
       <h2 class="card-title"><%= @group.group_admin.username %>から招待されています</h2>
-      <p><%= t '.title' %></p>
       <%= link_to t('defaults.login_with_line'), invitees_auth_at_provider_path(provider: :line, invite_token: @group.invite_token), class:"btn btn-primary", data: { turbo: false } %>
     </div>
   </div>

--- a/app/views/invitees/invitation/new.html.erb
+++ b/app/views/invitees/invitation/new.html.erb
@@ -1,0 +1,9 @@
+<div class="mx-auto max-w-4xl overflow-hidden bg-base-100 py-4 sm:px-24 sm:py-24 flex-auto">
+  <div class="card mx-8 max-w-full rounded-xl bg-white shadow-xl">
+    <div class="card-body mx-auto items-center text-center">
+      <h2 class="card-title"><%= @group.group_admin.username %>から招待されています</h2>
+      <p><%= t '.title' %></p>
+      <%= link_to t('defaults.login_with_line'), invitees_auth_at_provider_path(provider: :line, invite_token: @group.invite_token), class:"btn btn-primary", data: { turbo: false } %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,5 +21,6 @@
     <%= render "shared/flash_message" %>
     <%= yield %>
     <%= render "shared/footer" %>
+    <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
   </body>
 </html>

--- a/app/views/profiles/_groups.html.erb
+++ b/app/views/profiles/_groups.html.erb
@@ -1,5 +1,3 @@
 <% user.groups.each do |group| %>
-  <div class="btn-neutral-100 btn w-full">
-    <%= link_to group.name, group_path(group), data: { turbo: false } %>
-  </div>
+  <%= link_to group.name, group_path(group),class: "btn btn-neutral-100 w-full", data: { turbo: false } %>
 <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -27,7 +27,7 @@
 
         </div>
         <div class="w-full">
-          <p class=""><%= t 'defaults.group' %></p>
+          <p class="title-font text-xl font-semibold text-neutral-900"><%= t 'defaults.group' %></p>
           <% if @user.groups.present? %>
             <%= render partial: 'profiles/groups', locals: { user: @user } %>
           <% else %>
@@ -39,7 +39,7 @@
             <%= link_to t('.create_group'), new_group_path, class: "link text-xs", data: { turbo: false } %>
           </div>
         </div>
-        <div><%= t 'defaults.record' %></div>
+        <div class="title-font text-xl font-semibold text-neutral-900"><%= t 'defaults.record' %></div>
         <div class="stats stats-vertical my-2 w-full bg-accent-content shadow sm:stats-horizontal md:stats-vertical">
           <div class="stat">
             <div class="stat-title"><%= t '.no_alcohol_day_achievement' %></div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -4,7 +4,7 @@
       <h1 class="text-5xl font-bold">肝ログ</h1>
       <h2 class="text-2xl">LiverLog</h2>
       <p class="py-8">肝ログ（LiverLog）は、休肝日と飲酒日を記録することで、飲酒管理ができるサービスです。</p>
-      <%= link_to "LINEでログイン", auth_at_provider_path(provider: :line), class: "btn btn-primary" %>
+      <%= link_to t('defaults.login_with_line'), auth_at_provider_path(provider: :line), class: "btn btn-primary" %>
     </div>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -25,3 +25,8 @@ ja:
       record_type:
         no_drink: '休肝日'
         drink: '飲酒日'
+    user:
+      role:
+        admin: '管理者'
+        general: '一般ユーザー'
+        invitee: '招待ユーザー'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,8 @@ ja:
     top_page: 'トップページ'
     community: 'コミュニティ'
     login_with_line: 'LINEでログイン'
+    login_success: 'ログインしました'
+    login_failed: 'ログインに失敗しました'
     group: 'グループ'
     my_page: 'マイページ'
     record: '記録'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -20,6 +20,7 @@ ja:
     delete_success: '記録を削除しました'
     create_success: '記録を登録しました'
     update_success: '記録を更新しました'
+    access_denied: 'アクセス権限がありません'
   static_pages:
     top:
       title: 'トップページ'
@@ -75,6 +76,12 @@ ja:
     destroy:
       success: 'グループを削除しました'
       error: 'グループの削除に失敗しました'
+  invitees:
+    invitations:
+      new:
+        title: 'メンバー招待'
+        success: '招待しました'
+        error: '招待に失敗しました'
   simple_calendar:
     previous: "<<"
     next: ">>"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,11 @@ Rails.application.routes.draw do
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
+  namespace :invitees do
+    get 'invitation/new/:invite_token', to: 'invitation#new'
+    get 'invitation/first_login', to: 'invitation#first_login'
+    post 'oauth/callback', to: 'oauths#callback'
+    get 'oauth/callback', to: 'oauths#callback'
+    get 'oauth/:provider/:invite_token', to: 'oauths#oauth', as: :auth_at_provider
+  end
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,2 @@
 sorcery:
-  line_callback_url: 'https://81b5-210-228-24-71.ngrok-free.app/oauth/callback?provider=line'
+  line_callback_url: 'https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app//oauth/callback?provider=line'

--- a/db/migrate/20231107134515_add_column_to_groups.rb
+++ b/db/migrate/20231107134515_add_column_to_groups.rb
@@ -1,0 +1,7 @@
+class AddColumnToGroups < ActiveRecord::Migration[7.0]
+  def change
+    add_column :groups, :invite_token, :string
+
+    add_index :groups, :invite_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_01_114113) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_07_134515) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -40,6 +40,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_01_114113) do
     t.integer "group_admin_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "invite_token"
+    t.index ["invite_token"], name: "index_groups_on_invite_token", unique: true
   end
 
   create_table "user_groups", force: :cascade do |t|

--- a/test/controllers/invitees/invitation_controller_test.rb
+++ b/test/controllers/invitees/invitation_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class Invitees::InvitationControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get invitees_invitation_new_url
+    assert_response :success
+  end
+end

--- a/test/controllers/invitees/oauths_controller_test.rb
+++ b/test/controllers/invitees/oauths_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Invitees::OauthsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
* 一般ユーザーが作成したグループに知人を招待する機能を実装しました。
  * グループ作成時に招待トークンを作成し、招待URLに含めトークンを含め、グループを判別しています。
  * 招待URLは[LINE Social Plugins](https://developers.line.biz/ja/docs/line-social-plugins/general/overview/)を用いて、LINEで共有できるようにしています。
  * GETメソッドによりパラメータとして取得した招待トークンをセッション管理して、LINEログイン処理後にグループとユーザーを紐付けています。
* 「一般ユーザー」と「招待ユーザー」で機能に対する権限を設定しました。

## 確認方法
* グループ画面のメンバーを招待に「LINEで送る」ボタンが表示されている。
* ボタンをクリック後にLINEのトークで招待URLが共有できることを確認してください。
* 招待URLから、招待ログインページに遷移することを確認してください。
* LINEログイン完了後、招待ユーザー用の初回ログインページに遷移することを確認してください。
* 初回ログインページでは名前を修正できることを確認してください。
* 初回ログイン後、グループ詳細ページに遷移することを確認してください。
* 2回目以降はログイン処理後、グループ詳細ページに遷移することを確認してください。

## 影響範囲
* Groupテーブルに`invite_token`カラムを追加しました。
* Userモデルにenum型でユーザーの種類を追加しました。

## コメント
* LINEアカウントを複数持てないため、実際のLINEアカウントを用いた検証が不十分なので、今後要検討。