### PR TITLE
Fix:ユーザー招待機能の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,6 @@ class ApplicationController < ActionController::Base
   end
 
   def require_general
-    redirect_to profile_path, warning: t('defaults.access_denied') unless current_user.general?
+    redirect_to group_path(current_user.groups.first), warning: t('defaults.access_denied') unless current_user.general?
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,5 +1,6 @@
 class GroupsController < ApplicationController
   before_action :set_group, only: %i[show edit update destroy]
+  before_action :authorize_group, only: %i[show edit update destroy]
   skip_before_action :require_general, only: %i[show]
 
   def new
@@ -50,5 +51,9 @@ class GroupsController < ApplicationController
 
   def set_group
     @group = Group.find(params[:id])
+  end
+
+  def authorize_group
+    redirect_to group_path(current_user.groups.first), warning: t('defaults.access_denied') unless @group.users.exists?(current_user.id)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,6 +22,7 @@ class GroupsController < ApplicationController
   def show
     start_date = params.fetch(:start_time, Date.today).to_date
     @drink_record = @group.group_admin.drink_records.all
+    @admin_user = @group.group_admin
   end
 
   def edit; end
@@ -48,6 +49,6 @@ class GroupsController < ApplicationController
   end
 
   def set_group
-    @group = current_user.groups.find(params[:id])
+    @group = Group.find(params[:id])
   end
 end

--- a/app/controllers/invitees/invitation_controller.rb
+++ b/app/controllers/invitees/invitation_controller.rb
@@ -2,13 +2,14 @@ class Invitees::InvitationController < ApplicationController
   skip_before_action :require_login, only: %i[new create]
   skip_before_action :require_general, only: %i[new first_login update]
   before_action :group_invite_token, only: %i[new]
+  before_action :set_user, only: %i[first_login update]
 
   def new; end
 
   def first_login; end
 
   def update
-    if @user.update(user_params_with_days)
+    if @user.update(user_params)
       redirect_to group_path(@user.groups.first), success: 'プロフィールを登録しました'
     else
       flash.now[:error] = 'プロフィールの登録に失敗しました'
@@ -17,6 +18,10 @@ class Invitees::InvitationController < ApplicationController
   end
 
   private
+
+  def user_params
+    params.require(:user).permit(:username, :first_login)
+  end
 
   def set_user
     @user = User.find(current_user.id)

--- a/app/controllers/invitees/oauths_controller.rb
+++ b/app/controllers/invitees/oauths_controller.rb
@@ -6,23 +6,4 @@ class Invitees::OauthsController < ApplicationController
     session[:invite_token] = params[:invite_token]
     login_at(params[:provider])
   end
-
-  def callback
-    provider = params[:provider]
-    if @user = login_from(provider)
-      redirect_to group_path(@user.groups.first), success: "Logged in from #{provider.titleize}!"
-    else
-      begin
-        @user = create_from(provider)
-        @user.role = :invitee
-        @group = Group.find_by(invite_token: session[:invite_token])
-        @group.save_group_member(@user)
-        reset_session
-        auto_login(@user)
-        redirect_to invitees_invitation_first_login_path, success: "Logged in from #{provider.titleize}!"
-      rescue
-        redirect_to root_path, error: "Failed to login from #{provider.titleize}!"
-      end
-    end
-  end
 end

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -16,10 +16,21 @@ class OauthsController < ApplicationController
       end
     else
       begin
-        @user = create_from(provider)
-        reset_session
-        auto_login(@user)
-        redirect_to first_login_path, success: t('defaults.login_success')
+        if session[:invite_token].present?
+          @user = create_from(provider)
+          @user.role = :invitee
+          group = Group.find_by(invite_token: session[:invite_token])
+          binding.pry
+          group.save_group_member(@user)
+          reset_session
+          auto_login(@user)
+          redirect_to invitees_invitation_first_login_path, success: t('defaults.login_success')
+        else
+          @user = create_from(provider)
+          reset_session
+          auto_login(@user)
+          redirect_to first_login_path, success: t('defaults.login_success')
+        end
       rescue
         redirect_to root_path, error: t('defaults.login_failed')
       end

--- a/app/controllers/post_comments_controller.rb
+++ b/app/controllers/post_comments_controller.rb
@@ -1,4 +1,6 @@
 class PostCommentsController < ApplicationController
+  skip_before_action :require_general, only: %i[create destroy]
+
   def create
     comment = current_user.post_comments.new(post_comment_params)
     if comment.save

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, only: [:show]
+  skip_before_action :require_general, only: %i[show]
 
   def show
     @group = @post.group

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -15,6 +15,10 @@ class Group < ApplicationRecord
     User.find(self.group_admin_id)
   end
 
+  def group_admin?(user)
+    user == self.group_admin
+  end
+
   def set_invite_token
     self.invite_token = SecureRandom.hex(16)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
 
   validates :username, presence: true
   validates :comment, length: { maximum: 256 }
-  validates :non_drinking_days, presence: true
+  validates :non_drinking_days, presence: true, if: :general?
 
   enum role: { general: 0, invitee: 10, admin: 20 }
 

--- a/app/views/groups/_posts.html.erb
+++ b/app/views/groups/_posts.html.erb
@@ -16,7 +16,9 @@
     <% end %>
   <% end %>
 <% else %>
-  <div class="card rounded-box flex-col bg-white shadow-xl w-full my-8">
-    <%= t '.no_post' %>
+  <div class="card rounded-box bg-white shadow-xl w-full mt-4 p-4">
+    <div class="pl-6">
+      <%= t '.no_post' %>
+    </div>
   </div>
 <% end %>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -1,12 +1,15 @@
 <% content_for(:title, @group.name) %>
 <div class="flex flex-col p-4 md:flex-row md:p-8 flex-auto max-w-6xl mx-auto">
   <div class="flex flex-col md:w-1/3">
+    <h2 class="title-font text-lg font-semibold text-neutral-900"><%= t '.group_name' %></h2>
     <div class="card p-4 bg-primary bg-opacity-50">
       <h2 class="title-font text-2xl font-semibold text-neutral-900"><%= @group.name %></h2>
-      <div class="text-right">
-        <%= link_to (t '.edit'), edit_group_path(@group), class:"btn btn-info btn-sm" %>
-        <%= link_to (t '.delete'), group_path(@group), class:"btn btn-error btn-sm", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") }  %>
-      </div>
+      <% if @group.group_admin?(current_user) %>
+        <div class="text-right">
+          <%= link_to (t '.edit'), edit_group_path(@group), class:"btn btn-info btn-sm" %>
+          <%= link_to (t '.delete'), group_path(@group), class:"btn btn-error btn-sm", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") }  %>
+        </div>
+      <% end %>
     </div>
     <div class="card rounded-box flex-grow place-items-center bg-white shadow-xl mt-4">
       <div class="w-full p-4">
@@ -35,7 +38,7 @@
             <h2 class="title-font text-lg font-semibold text-neutral-900"><%= t '.member' %></h2>
             <% if @group.users.present? %>
               <% @group.users.each do |user| %>
-                <div class="flex flex-row items-center p-4 text-left md:text-left border border-primary rounded-lg">
+                <div class="flex flex-row items-center p-4 text-left md:text-left border border-primary rounded-lg mb-2">
                   <div class="avatar">
                     <div class="h-12 w-12 rounded-full">
                       <%= image_tag user.image %>
@@ -51,10 +54,12 @@
                 <%= t '.no_group' %>
               </div>
             <% end %>
-            <div class="text-left py-4">
-              <p class="font-semibold"><%= t '.invite' %></p>
-              <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://liverlog.fly.dev/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
-            </div>
+            <% if @group.group_admin?(current_user) %>
+              <div class="text-left py-4">
+                <p class="font-semibold"><%= t '.invite' %></p>
+                <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
+              </div>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,9 @@
     <ul class="menu menu-horizontal invisible px-1 md:visible">
       <li><a><%= t 'defaults.community' %></a></li>
     </ul>
-    <%= link_to t('defaults.record'), new_drink_record_path, class: 'btn btn-accent', data: { turbo: false } %>
+    <% if current_user.general? %>
+      <%= link_to t('defaults.record'), new_drink_record_path, class: 'btn btn-accent', data: { turbo: false } %>
+    <% end %>
     <div class="dropdown dropdown-end">
       <div class="flex-none">
         <label tabindex="0" class="btn btn-ghost btn-circle avatar mx-4">
@@ -15,9 +17,15 @@
           </div>
         </label>
         <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-32">
-          <li>
-            <%= link_to t('defaults.my_page'), profile_path %>
-          </li>
+          <% if current_user.general? %>
+            <li>
+              <%= link_to t('defaults.my_page'), profile_path %>
+            </li>
+          <% elsif current_user.invitee? %>
+            <li>
+              <%= link_to t('defaults.group'), group_path(current_user.groups.first) %>
+            </li>
+          <% end %>
           <li class="md:hidden"><a><%= t 'defaults.community' %></a></li>
         </ul>
       </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -69,6 +69,7 @@ ja:
       no_alcohol_day: '休肝日'
       no_alcohol_day_achievement: '休肝日達成率（今月）'
       alcohol_intake: '総アルコール摂取量（今月）'
+      group_name: 'グループ名'
       admin: '管理者'
       member: 'メンバー'
       invite: 'メンバーを招待'
@@ -93,6 +94,8 @@ ja:
         title: 'メンバー招待'
         success: '招待しました'
         error: '招待に失敗しました'
+      first_login:
+        title: 'ユーザー情報登録'
   simple_calendar:
     previous: "<<"
     next: ">>"


### PR DESCRIPTION
## 概要
* LINEログインを用いた招待ユーザーのログイン機能の修正を行いました。
* 招待ユーザーに対する、ページ内の表示内容の制限や機能制限を行いました。
## 確認方法
* グループ詳細ページから招待URLをLINEで送信し、送信先のユーザーが招待URLからLINEログインできることを確認してください。
* 初回ログイン時に招待ユーザーのユーザー名を修正できることを確認してください。
* 初回ログイン後、招待されたグループ詳細ページに遷移することを確認してください。
* グループ詳細ページにおいて招待したユーザーが表示されていることを確認してください。
## 影響範囲
* 一般ユーザーとしてのLINEログインと招待ユーザーのLINEログインについて、当初コントローラを分けていましたが、それでは招待ユーザーとしてのログインができなかったため、`app/controllers/oauths_controller.rb`の`callback`メソッドに招待ユーザーを作成するための処理を追記しました。
## コメント
* 開発段階で自分以外の人がLINEログインを試す場合は、テスターとして事前に招待が必要だったことを初めて知りました･･･
* LINEのチャネルにはコールバックURLを一つしか登録できないため、コントローラを分けてもうまくいかないことに気づき、`callback`は統一した方が良さそうです。（他の外部認証はどうでしょう？）