### PR TITLE
Add:LINEメッセージで休肝日を知らせる機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,8 @@ gem 'enum_help'
 
 gem 'line-bot-api'
 
+gem 'whenever', require: false
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     config (4.2.1)
@@ -297,6 +298,8 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.6.11)
@@ -331,6 +334,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  whenever
 
 RUBY VERSION
    ruby 3.2.2p53

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -57,7 +57,7 @@
             <% if @group.group_admin?(current_user) %>
               <div class="text-left py-4">
                 <p class="font-semibold"><%= t '.invite' %></p>
-                <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
+                <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="<%= Settings.page_url[:page_url] %>/invitees/invitation/new/<%= @group.invite_token %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
               </div>
             <% end %>
           </div>

--- a/app/views/shared/_drink_record_summary.html.erb
+++ b/app/views/shared/_drink_record_summary.html.erb
@@ -1,4 +1,4 @@
-<div class="stats stats-vertical my-2 w-full bg-accent-content shadow md:stats-horizontal md:grid-cols-2">
+<div class="stats stats-vertical my-2 w-full bg-accent-content shadow grid-cols-2">
   <div class="stat">
     <div class="stat-title"><%= t 'defaults.no_alcohol_day_achievement' %></div>
     <div class="stat-value"><%= user.monthly_no_drink_achievement %>%</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -24,10 +24,12 @@
             <li>
               <%= t('defaults.group') %>
               <ul>
-                <% current_user.groups.each do |group| %>
-                  <li>
-                    <%= link_to group.name, group_path(group) %>
-                  </li>
+                <% if current_user.groups.exists? %>
+                  <% current_user.groups.each do |group| %>
+                    <li>
+                      <%= link_to group.name, group_path(group) %>
+                    </li>
+                  <% end %>
                 <% end %>
               </ul>
             </li>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -223,10 +223,10 @@ Rails.application.config.sorcery.configure do |config|
   config.line.secret = Rails.application.credentials.dig(:line, :channel_secret)
   config.line.callback_url = Settings.sorcery[:line_callback_url]
   config.line.scope = "profile openid"
-  config.line.bot_prompt = "normal"
+  config.line.bot_prompt = "aggressive"
   config.line.user_info_mapping = {username: 'displayName', image: 'pictureUrl'}
 
-  
+
   # For information about Discord API
   # https://discordapp.com/developers/docs/topics/oauth2
   # config.discord.key = "xxxxxx"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,16 @@
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+
+# cronを実行する環境変数
+rails_env = ENV['RAILS_ENV'] || :development
+
+# cronを実行する環境変数をセット
+set :environment, rails_env
+
+# cronのログの吐き出し場所
+set :output, "#{Rails.root}/log/cron.log"
+
+#定期実行したい処理を記入
+every 1.day, at: '9am' do
+  rake 'line_push:line_no_drink_day'
+end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,4 @@
 sorcery:
   line_callback_url: 'https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app/oauth/callback?provider=line'
+page_url:
+  page_url: 'https://0da4-2400-4052-6960-9b00-a4b4-fc11-952a-f241.ngrok-free.app'

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,4 @@
 sorcery:
   line_callback_url: 'https://liverlog.fly.dev/oauth/callback?provider=line'
+page_url:
+  page_url: 'https://liverlog.fly.dev'

--- a/lib/tasks/line_push.rake
+++ b/lib/tasks/line_push.rake
@@ -4,8 +4,8 @@ namespace :line_push do
     require 'line/bot'
 
     message = {
-      type: 'text',
-      text: '今日は休肝日です！'
+      type: "text",
+      text: "今日は休肝日です！肝ログにアクセスして休肝日を記録しましょう！ #{Settings.page_url[:page_url]}/profile"
     }
 
     client ||= Line::Bot::Client.new { |config|
@@ -16,7 +16,7 @@ namespace :line_push do
 
     reminder_users = User.where(reminder: true)
     reminder_users.each do |user|
-      if user.non_drink_days.include?(Date.today.wday)
+      if user.non_drinking_days&.include?(Date.today.wday)
         client.push_message(user.authentications.first.uid, message)
       end
     end


### PR DESCRIPTION
## 概要
* 休肝日をLINEメッセージで通知する機能を実装しました。（Rakeタスクの`line_no_drink_day`）
## 確認方法
* 通知が送られてくるのはリマインダーを登録しているユーザーのみであることを確認してください。
* 事前に登録した休肝日の朝9時に通知が送られてくることを確認してください。