### PR TITLE
Add:モデルスペックの追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-
+  gem "webmock"
 end
 
 gem "dockerfile-rails", ">= 1.5", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,8 @@ GEM
     config (4.2.1)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.3.3)
       railties (>= 6.0.0)
@@ -152,6 +154,7 @@ GEM
     faraday-net_http (3.0.2)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    hashdiff (1.1.0)
     hashie (5.0.0)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
@@ -339,6 +342,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.19.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.9)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -382,6 +389,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webmock
   whenever
 
 RUBY VERSION

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,4 +6,5 @@ class Post < ApplicationRecord
   has_many :post_likes, dependent: :destroy
 
   validates :id, uniqueness: { scope: :group_id }
+  validates :content, length: { maximum: 256 }
 end

--- a/app/models/post_comment.rb
+++ b/app/models/post_comment.rb
@@ -2,5 +2,5 @@ class PostComment < ApplicationRecord
   belongs_to :user
   belongs_to :post
 
-  validates :message, presence: true, length: { maximum: 1000 }
+  validates :message, presence: true, length: { maximum: 256 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,10 @@ class User < ApplicationRecord
 
   validates :username, presence: true
   validates :comment, length: { maximum: 256 }
-  validates :non_drinking_days, presence: true, if: :general?
+  validates :non_drinking_days, presence: true, if: -> { self.role == 'general' || self.role == 'admin' }
+  validates :role, presence: true
+  validates :reminder, inclusion: { in: [true, false] }
+  validates :first_login, inclusion: { in: [true, false] }
 
   enum role: { general: 0, invitee: 10, admin: 20 }
 

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -5,7 +5,7 @@
       <h1 class="text-5xl font-bold">肝ログ</h1>
       <h2 class="text-2xl">LiverLog</h2>
       <p class="py-8">肝ログ（LiverLog）は、休肝日と飲酒日を記録することで、飲酒管理ができるサービスです。</p>
-      <%= link_to auth_at_provider_path(provider: :line), class: "inline-block text-center" do %>
+      <%= link_to auth_at_provider_path(provider: :line), class: "inline-block text-center", id: "line-login-btn" do %>
         <%= image_tag "btn_login_base.png" %>
       <% end %>
     </div>

--- a/spec/factories/drink_records.rb
+++ b/spec/factories/drink_records.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :drink_record do
+    record_type { 1 }
+    start_time { "2021-01-01 00:00:00" }
+    drink_type { "ビール" }
+    drink_volume { 350 }
+    alcohol_percentage { 5.0 }
+    association :user
+
+    trait :no_drink do
+      record_type { 0 }
+      drink_volume { 0 }
+      alcohol_percentage { 0.0 }
+    end
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :group do
+    sequence(:name) { |n| "group#{n}" }
+    invite_token { SecureRandom.hex(16) }
+    association :group_admin, factory: :user
+  end
+end

--- a/spec/factories/post_comments.rb
+++ b/spec/factories/post_comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :post_comment do
+    sequence(:message) { |n| "コメント#{n}" }
+    association :user
+    association :post
+  end
+end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :post do
+    sequence(:content) { |n| "content#{n}" }
+    association :user
+    association :group
+    association :drink_record
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,5 +15,7 @@ FactoryBot.define do
 
   trait :invitee do
     role { :invitee }
+    comment { nil }
+    non_drinking_days { nil }
   end
 end

--- a/spec/models/drink_records_spec.rb
+++ b/spec/models/drink_records_spec.rb
@@ -1,0 +1,73 @@
+require 'rails_helper'
+
+RSpec.describe DrinkRecord, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'バリデーション' do
+    context 'バリデーションに通る' do
+      it '休肝日記録の保存に成功する' do
+        drink_record = build(:drink_record, user: user)
+        expect(drink_record).to be_valid
+        expect(drink_record.errors).to be_empty
+      end
+      it 'お酒の記録の保存に成功する' do
+        drink_record = build(:drink_record, :no_drink, user: user)
+        expect(drink_record).to be_valid
+        expect(drink_record.errors).to be_empty
+      end
+    end
+
+    context 'バリデーションに失敗する' do
+      context '休肝日記録の保存の場合' do
+        it '記録の種類がない' do
+          drink_record = build(:drink_record, :no_drink, user: user, record_type: nil)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:record_type]).to include("を入力してください")
+        end
+        it '記録日が未来の日付になっている' do
+          drink_record = build(:drink_record, :no_drink, user: user, start_time: DateTime.current + 1)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:start_time]).to include("未来の日付は使えません")
+        end
+        it '飲酒量が0mlとなる' do
+          drink_record = build(:drink_record, :no_drink, user: user, drink_volume: 50)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:drink_volume]).to be_present
+        end
+        it 'アルコール度数が0%となる' do
+          drink_reccord = build(:drink_record, :no_drink, user: user, alcohol_percentage: 5.0)
+          expect(drink_reccord).to be_invalid
+          expect(drink_reccord.errors[:alcohol_percentage]).to be_present
+        end
+      end
+
+      context 'お酒の記録の保存の場合' do
+        it '記録の種類がない' do
+          drink_record = build(:drink_record, user: user, record_type: nil)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:record_type]).to include("を入力してください")
+        end
+        it '記録日が未来の日付になっている' do
+          drink_record = build(:drink_record, user: user, start_time: DateTime.current + 1)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:start_time]).to include("未来の日付は使えません")
+        end
+        it '飲酒量が0ml以下となる' do
+          drink_record = build(:drink_record, user: user, drink_volume: -1)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:drink_volume]).to include("は0以上の値にしてください")
+        end
+        it 'アルコール度数が0%未満となる' do
+          drink_record = build(:drink_record, user: user, alcohol_percentage: -1.0)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:alcohol_percentage]).to be_present
+        end
+        it 'アルコール度数が100%以上となる' do
+          drink_record = build(:drink_record, user: user, alcohol_percentage: 100.1)
+          expect(drink_record).to be_invalid
+          expect(drink_record.errors[:alcohol_percentage]).to be_present
+        end
+      end
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe Group, type: :model do
+  let(:user) { create(:user) }
+
+  describe 'バリデーションに通る' do
+    context 'グループの保存に成功する' do
+      it 'グループ名、グループ管理者ID、招待トークンがある' do
+        group = build(:group, group_admin_id: user.id)
+        expect(group).to be_valid
+        expect(group.errors).to be_empty
+      end
+    end
+  end
+
+  describe 'バリデーションに失敗する' do
+    context 'グループの保存に失敗する' do
+      it 'グループ名がない' do
+        group = build(:group, name: nil, group_admin_id: user.id)
+        expect(group).to be_invalid
+        expect(group.errors[:name]).to be_present
+      end
+      it 'グループ管理者IDがない' do
+        group = build(:group, group_admin_id: nil)
+        expect(group).to be_invalid
+        expect(group.errors[:group_admin_id]).to be_present
+      end
+      it '招待トークンがない' do
+        group = build(:group, invite_token: nil, group_admin_id: user.id)
+        expect(group).to be_invalid
+        expect(group.errors[:invite_token]).to be_present
+      end
+      it '招待トークンが重複している' do
+        group = create(:group, group_admin_id: user.id)
+        group2 = build(:group, invite_token: group.invite_token, group_admin_id: user.id)
+        expect(group2).to be_invalid
+        expect(group2.errors[:invite_token]).to be_present
+      end
+    end
+  end
+end

--- a/spec/models/post_comment_spec.rb
+++ b/spec/models/post_comment_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe PostComment, type: :model do
+  let(:user) { create(:user) }
+  let(:group) { create(:group, group_admin_id: user.id) }
+  let(:drink_record) { create(:drink_record, user: user) }
+  let(:post) { create(:post, user: user, group: group, drink_record: drink_record) }
+
+  describe 'バリデーションに通る' do
+    context '投稿の保存に成功する' do
+      it 'ユーザーID、投稿ID、メッセージがある' do
+        post_comment = build(:post_comment, user: user, post: post)
+        expect(post_comment).to be_valid
+        expect(post_comment.errors).to be_empty
+      end
+    end
+  end
+
+  describe 'バリデーションに失敗する' do
+    context '投稿の保存に失敗する' do
+      it '文字数が256文字を超える' do
+        post_comment = build(:post_comment, message: 'a' * 257, user: user, post: post)
+        expect(post_comment).to be_invalid
+        expect(post_comment.errors[:message]).to be_present
+      end
+      it 'ユーザーIDがない' do
+        post_comment = build(:post_comment, user: nil, post: post)
+        expect(post_comment).to be_invalid
+        expect(post_comment.errors[:user]).to be_present
+      end
+      it '投稿IDがない' do
+        post_comment = build(:post_comment, user: user, post: nil)
+        expect(post_comment).to be_invalid
+        expect(post_comment.errors[:post]).to be_present
+      end
+    end
+  end
+end

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe Post, type: :model do
+  let(:user) { create(:user) }
+  let(:group) { create(:group, group_admin_id: user.id) }
+  let(:drink_record) { create(:drink_record, user: user) }
+
+  describe 'バリデーションに通る' do
+    context '投稿の保存に成功する' do
+      it 'ユーザーID、グループID、飲酒記録IDがある' do
+        post = build(:post, user: user, group: group, drink_record: drink_record)
+        expect(post).to be_valid
+        expect(post.errors).to be_empty
+      end
+    end
+  end
+
+  describe 'バリデーションに失敗する' do
+    context '投稿の保存に失敗する' do
+      it '文字数が256文字を超える' do
+        post = build(:post, content: 'a' * 257, user: user, group: group, drink_record: drink_record)
+        expect(post).to be_invalid
+        expect(post.errors[:content]).to be_present
+      end
+      it 'ユーザーIDがない' do
+        post = build(:post, user: nil, group: group, drink_record: drink_record)
+        expect(post).to be_invalid
+        expect(post.errors[:user]).to be_present
+      end
+      it 'グループIDがない' do
+        post = build(:post, user: user, group: nil, drink_record: drink_record)
+        expect(post).to be_invalid
+        expect(post.errors[:group]).to be_present
+      end
+      it '飲酒記録IDがない' do
+        post = build(:post, user: user, group: group, drink_record: nil)
+        expect(post).to be_invalid
+        expect(post.errors[:drink_record]).to be_present
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,127 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe '一般ユーザー' do
+    describe 'バリデーションに通る' do
+      it 'ユーザーの保存に成功する' do
+        user = build(:user)
+        expect(user).to be_valid
+        expect(user.errors).to be_empty
+      end
+    end
+
+    describe 'バリデーションに失敗する' do
+      it '名前がない' do
+        user = build(:user, username: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:username]).to include("を入力してください")
+      end
+      it 'コメントが256文字以上になっている' do
+        user = build(:user, comment: "a" * 257)
+        expect(user).to be_invalid
+        expect(user.errors[:comment]).to include("は256文字以内で入力してください")
+      end
+      it '休肝日数がない' do
+        user = build(:user, non_drinking_days: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:non_drinking_days]).to include("を入力してください")
+      end
+      it '役割がない' do
+        user = build(:user, role: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:role]).to include("を入力してください")
+      end
+      it 'リマインダーの設定がない' do
+        user = build(:user, reminder: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:reminder]).to be_present
+      end
+      it '初回ログインの設定がない' do
+        user = build(:user, first_login: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:first_login]).to be_present
+      end
+    end
+  end
+
+  describe '管理者ユーザー' do
+    describe 'バリデーションに通る' do
+      it 'ユーザーの保存に成功する' do
+        user = build(:user, :admin)
+        expect(user).to be_valid
+        expect(user.errors).to be_empty
+      end
+    end
+
+    describe 'バリデーションに失敗する' do
+      it '名前がない' do
+        user = build(:user, :admin, username: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:username]).to include("を入力してください")
+      end
+      it 'コメントが256文字以上になっている' do
+        user = build(:user, :admin, comment: "a" * 257)
+        expect(user).to be_invalid
+        expect(user.errors[:comment]).to include("は256文字以内で入力してください")
+      end
+      it '休肝日数がない' do
+        user = build(:user, :admin, non_drinking_days: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:non_drinking_days]).to include("を入力してください")
+      end
+      it '役割がない' do
+        user = build(:user, :admin, role: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:role]).to include("を入力してください")
+      end
+      it 'リマインダーの設定がない' do
+        user = build(:user, :admin, reminder: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:reminder]).to be_present
+      end
+      it '初回ログインの設定がない' do
+        user = build(:user, :admin, first_login: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:first_login]).to be_present
+      end
+    end
+  end
+
+  describe '招待ユーザー' do
+    describe 'バリデーションに通る' do
+      it 'ユーザーの保存に成功する' do
+        user = build(:user, :invitee)
+        expect(user).to be_valid
+        expect(user.errors).to be_empty
+      end
+    end
+
+    describe 'バリデーションに失敗する' do
+      it '名前がない' do
+        user = build(:user, :invitee, username: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:username]).to include("を入力してください")
+      end
+      it 'コメントが256文字以上になっている' do
+        user = build(:user, :invitee, comment: "a" * 257)
+        expect(user).to be_invalid
+        expect(user.errors[:comment]).to include("は256文字以内で入力してください")
+      end
+      it '役割がない' do
+        user = build(:user, :invitee, role: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:role]).to include("を入力してください")
+      end
+      it 'リマインダーの設定がない' do
+        user = build(:user, :invitee, reminder: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:reminder]).to be_present
+      end
+      it '初回ログインの設定がない' do
+        user = build(:user, :invitee, first_login: nil)
+        expect(user).to be_invalid
+        expect(user.errors[:first_login]).to be_present
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -30,6 +30,14 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+
+# WebMock.disable_net_connect!(allow: [
+#   lambda{|uri| uri.host.length % 2 == 0 },
+#   /chrome:4444/,
+#   /web:/,
+# ])
+# WebMock.disable_net_connect!(allow_localhost: true, allow: %r{http://chrome:4444/wd/hub/session}, allow: %r{http://web:})
+
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = Rails.root.join('spec/fixtures')
@@ -63,8 +71,8 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   config.include FactoryBot::Syntax::Methods
-  config.include LoginMacros
-  config.include Sorcery::TestHelpers::Rails::Controller
+  # config.include LoginMacros
+  config.include Sorcery::TestHelpers::Rails::Controller, type: :controller
   config.include Sorcery::TestHelpers::Rails::Request, type: :request
-  config.include Sorcery::TestHelpers::Rails::Integration, type: :feature
+  config.include Sorcery::TestHelpers::Rails::Integration, type: :system
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'capybara/rspec'
+# require 'webmock/rspec'
 
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/login_macros.rb
+++ b/spec/support/login_macros.rb
@@ -1,6 +1,6 @@
 module LoginMacros
-  def login_as(user)
-    login_user(user)
+  def login_line(user)
+    login_user(user, profile_path)
     visit profile_path
   end
 end

--- a/spec/system/drink_records_spec.rb
+++ b/spec/system/drink_records_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "休肝日&飲酒日を記録する", type: :system do
 
   describe "休肝日を記録する" do
     before do
-    login_as(user)
+    login_line(user)
     click_link "drink-record-btn"
     end
 

--- a/spec/system/line_login_spec.rb
+++ b/spec/system/line_login_spec.rb
@@ -2,9 +2,22 @@ require 'rails_helper'
 
 RSpec.describe 'User Login with LINE via OauthsController', type: :system do
   before do
-    # SorceryのOAuth認証プロセスを模倣する
-    allow_any_instance_of(OauthsController).to receive(:login_at).and_return(mocked_auth_hash)
-    allow_any_instance_of(OauthsController).to receive(:create_from).and_return(mocked_user)
+    # LINE認証のレスポンスを模倣
+    # WebMock.stub_request(:post, "https://api.line.me/oauth2/v2.1/token")
+    #   .to_return(
+    #     status: 200,
+    #     body: { access_token: "mock_access_token", token_type: "Bearer" }.to_json,
+    #     headers: { 'Content-Type' => 'application/json' }
+    #   )
+
+    # # その他必要なAPI呼び出しを模倣
+    # # 例: ユーザー情報取得API
+    # WebMock.stub_request(:get, "https://api.line.me/v2/profile")
+    #   .to_return(
+    #     status: 200,
+    #     body: { userId: "mock_user_id", displayName: "mock_user" }.to_json,
+    #     headers: { 'Content-Type' => 'application/json' }
+    #   )
   end
 
   it 'allows a user to log in with LINE' do


### PR DESCRIPTION
## 概要
* モデルスペックを実装し、テストを行いました。
* テストの結果、幾つか修正を行いました。
## 確認方法
* `docker compose exec web rspec spec/models`を実行し、モデルスペックが通ることを確認してください。
## 影響範囲
* `User`モデルの`:non_drinking_days`について管理者ユーザーにもバリデーションを適用するようにしました。
* `User`モデルの`:role`カラムについてバリデーションを追加しました。
* `User`モデルの`:reminder`カラム、`first_login`カラムについて、真偽値のみの保存を許可するバリデーションを追加しました。
* `Post`モデルの`:content`カラムについて文字数の上限を256文字とするバリデーションを追加しました。
* `PostComment`モデルの`:message`カラムについて文字数の上限を変更しました。
## コメント
* システムスペックについて導入予定ですが、LINEログインによる外部認証についてモックを作成するためにWebmock gemをインストールしある程度設定したもののコメントアウトしてあります。