### PR TITLE
Fix:管理者機能の修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,13 +4,20 @@ class ApplicationController < ActionController::Base
   before_action :require_login
   before_action :require_general
 
+  rescue_from CanCan::AccessDenied do |_exception|
+    redirect_to main_app.root_path, error: '画面を閲覧する権限がありません。'
+  end
+
   private
 
   def not_authenticated
-      redirect_to main_app.root_path, error: t('defaults.not_authenticated')
+    redirect_to main_app.root_path, error: t('defaults.not_authenticated')
   end
 
   def require_general
-    redirect_to group_path(current_user.groups.first), warning: t('defaults.access_denied') unless current_user.general? || current_user.admin?
+    return if current_user.general? || current_user.admin?
+
+    redirect_to group_path(current_user.groups.first),
+                warning: t('defaults.access_denied')
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,11 +4,9 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    def initialize(user)
-      if user.admin? # 管理者じゃなかったらこのメソッドを抜ける
-        can :access, :rails_admin # 管理者画面のアクセス許可
-        can :manage, :all # 管理権限許可
-      end
-    end
+    return unless user.admin? # 管理者じゃなかったらこのメソッドを抜ける
+
+    can :access, :rails_admin # 管理者画面のアクセス許可
+    can :manage, :all # 管理権限許可
   end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -21,13 +21,17 @@
           </div>
         </label>
         <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-32">
+          <% if current_user.admin? %>
+            <li>
+              <%= link_to t('defaults.admin_page'), rails_admin_path %>
+            </li>
+          <% end %>
           <% if current_user.general? || current_user.admin? %>
             <li>
               <%= link_to t('defaults.my_page'), profile_path %>
             </li>
-            <li>
+            <ul>
               <%= t('defaults.group') %>
-              <ul>
                 <% if current_user.groups.exists? %>
                   <% current_user.groups.each do |group| %>
                     <% if group.persisted? %>
@@ -37,8 +41,7 @@
                     <% end %>
                   <% end %>
                 <% end %>
-              </ul>
-            </li>
+            </ul>
           <% elsif current_user.invitee? %>
             <li>
               <%= t('defaults.group') %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,7 @@ ja:
     not_authenticated: 'ログインしてください'
     group: 'グループ'
     my_page: 'マイページ'
+    admin_page: '管理ページ'
     record: '記録'
     terms_of_service: '利用規約'
     privacy_policy: 'プライバシーポリシー'

--- a/fly.toml
+++ b/fly.toml
@@ -1,4 +1,4 @@
-# fly.toml app configuration file generated for liverlog on 2023-12-11T22:36:21+09:00
+# fly.toml app configuration file generated for liverlog on 2024-01-20T02:34:46+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
@@ -8,6 +8,9 @@ primary_region = "nrt"
 console_command = "/rails/bin/rails console"
 
 [build]
+
+[deploy]
+  release_command = "./bin/rails db:prepare"
 
 [http_service]
   internal_port = 3000
@@ -20,7 +23,7 @@ console_command = "/rails/bin/rails console"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory_mb = 1024
+  memory_mb = 256
 
 [[statics]]
   guest_path = "/app/public"


### PR DESCRIPTION
## 概要
* 管理者機能の修正を行いました。
* 管理者権限がないユーザーが管理ページにアクセスを試みた際について、トップページにフラッシュメッセージを表示しつつ遷移するように変更しました。
* 管理ページ遷移時のバグを修正しました。
* 管理者が管理ページに遷移しやすいようにしました。
## 確認方法
* 管理者権限を持つユーザーでログインし、ヘッダー部に管理ページへのリンクが表示されていることを確認してください。
* 管理者権限を持たないユーザーには管理ページへのリンクが表示されないことを確認してください。
* 管理者権限を持たないユーザーが管理ページにアクセスを試みた場合にフラッシュメッセージを表示しながら、トップページに遷移することを確認してください。