### PR TITLE
Add:週間記録のまとめの通知機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,9 @@ https://liverlog-bff5ca6e49ba.herokuapp.com
     * 投稿に対していいねをする
 
 ### 機能の実装方針予定
-* Ruby: 3.2.2
-* Rails: 7.0.8
 * CSSフレームワーク: Tailwind CSS, daisyUI
 * ユーザ登録及び認証機能: Sorcery
-* ユーザ招待機能:
-* 画像アップロード: Active Storage
 * カレンダー表示: simple_calendar
-* グラフ表示: chartkick
 * LINE通知: LINE Messaging API及びLINE Messaging API SDK for Ruby
 
 ■ 開発環境: Docker
@@ -69,7 +64,7 @@ https://liverlog-bff5ca6e49ba.herokuapp.com
 ■ インフラ:
  
 * Webアプリケーションサーバ: Heroku
-* データベースサーバ: PostgreSQL（Fly Postgres）
+* データベースサーバ: PostgreSQL
 
 ### 画面遷移図
 Figma：https://www.figma.com/file/U2WJ5uU9adWanRfoHdO6BJ/%E8%82%9D%E3%83%AD%E3%82%B0%EF%BC%88LiverLog%EF%BC%89?type=design&node-id=14%3A38&mode=design&t=HXMrChrXeIq5pcmc-1

--- a/app/views/shared/_drink_record_summary.html.erb
+++ b/app/views/shared/_drink_record_summary.html.erb
@@ -6,13 +6,13 @@
   </div>
   <div class="stat">
     <div class="stat-title"><%= t 'defaults.alcohol_intake' %></div>
-    <div class="stat-value"><%= user.monthly_total_amount_alcohol %>ml</div>
+    <div class="stat-value"><%= user.monthly_total_amount_alcohol %>g</div>
     <% if user.compare_amount_last_manth_total_amount_alcohol > 0 %>
-      <div class="stat-desc">↗︎ <%= user.compare_amount_last_manth_total_amount_alcohol %>ml (<%= user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+      <div class="stat-desc">↗︎ <%= user.compare_amount_last_manth_total_amount_alcohol %>g (<%= user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
     <% elsif user.compare_amount_last_manth_total_amount_alcohol < 0 %>
-      <div class="stat-desc">↘︎ <%= user.compare_amount_last_manth_total_amount_alcohol %>ml (<%= user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+      <div class="stat-desc">↘︎ <%= user.compare_amount_last_manth_total_amount_alcohol %>g (<%= user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
     <% else %>
-      <div class="stat-desc">- <%= user.compare_amount_last_manth_total_amount_alcohol %>ml (<%= user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
+      <div class="stat-desc">- <%= user.compare_amount_last_manth_total_amount_alcohol %>g (<%= user.compare_rate_last_manth_total_amount_alcohol %>%)</div>
     <% end %>
   </div>
   <div class="stat">

--- a/lib/tasks/line_summary_push.rake
+++ b/lib/tasks/line_summary_push.rake
@@ -1,0 +1,39 @@
+namespace :line_summary_push do
+  desc '一週間の記録をまとめてLINEで通知する'
+  task line_summary_push: :environment do
+    require 'line/bot'
+
+    message = {
+      type: 'text',
+      text: ''
+    }
+
+    client ||= Line::Bot::Client.new do |config|
+      config.channel_id = Rails.application.credentials.dig(:line_message, :channel_id)
+      config.channel_secret = Rails.application.credentials.dig(:line_message, :channel_secret)
+      config.channel_token = Rails.application.credentials.dig(:line_message, :channel_token)
+    end
+
+    def week_summary(user)
+      user.drink_records.where(start_time: Date.today.prev_week.beginning_of_week..Date.today.prev_week.end_of_week)
+    end
+
+    def week_total_amount_alcohol(user)
+      total_amount_alcohol = 0
+      week_summary(user).drink.each do |drink_record|
+        amount_alcohol = drink_record.drink_volume.to_f * (drink_record.alcohol_percentage.to_f * 0.01) * 0.8
+        total_amount_alcohol += amount_alcohol
+      end
+      total_amount_alcohol.round(1)
+    end
+
+    reminder_users = User.where(reminder: true)
+    if Date.today.monday?
+      reminder_users.each do |user|
+        message[:text] =
+          "先週（月〜日）の記録です！\n休肝日：#{week_summary(user).no_drink.count}日\nお酒を飲んだ日：#{week_summary(user).drink.count}日\nお酒を飲んだ日の合計量：#{week_total_amount_alcohol(user)}g\nお酒を飲んだ日の合計金額：#{week_summary(user).drink.sum(:price)}円\n\n今週も頑張りましょう！"
+        client.push_message(user.authentications.first.uid, message)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
* 1週間の記録をまとめたものをLINEメッセージで通知する機能を追加しました。
## 確認方法
* 毎週月曜日に前週1週間の記録がまとめられたメッセージが届くことを確認してください。
## コメント
* 当初、Wheneverライブラリを導入して自動送信するつもりでしたが、デプロイ先をfly.ioからHerokuに変更したため、Heroku Schedulerを用いてスケジュール管理しています。