### PR TITLE
Add:記録フォームの表示・非表示を切り替え

### DIFF
--- a/app/controllers/drink_records_controller.rb
+++ b/app/controllers/drink_records_controller.rb
@@ -26,6 +26,7 @@ class DrinkRecordsController < ApplicationController
   def edit; end
 
   def update
+    binding.pry
     @drink_record.assign_attributes(drink_record_params)
     if @drink_record.save
       redirect_to drink_record_path(@drink_record), success: t('defaults.update_success')
@@ -43,8 +44,15 @@ class DrinkRecordsController < ApplicationController
   private
 
   def drink_record_params
-    params.require(:drink_record).permit(:user_id, :record_type, :start_time, :drink_type, :drink_volume,
-                                         :alcohol_percentage, :price)
+    record_params = params.require(:drink_record).permit(:user_id, :record_type, :start_time, :drink_type, :drink_volume,
+                                                         :alcohol_percentage, :price)
+    return record_params unless record_params[:record_type] == 'no_drink'
+
+    record_params[:drink_type] = nil
+    record_params[:drink_volume] = 0
+    record_params[:alcohol_percentage] = 0
+    record_params[:price] = 0
+    record_params
   end
 
   def set_drink_record

--- a/app/javascript/controllers/alcohol_calculator.js
+++ b/app/javascript/controllers/alcohol_calculator.js
@@ -1,4 +1,4 @@
-const calculateAndDisplayIntake = () => {
+document.addEventListener('turbo:load', () => {
   var volumeElement = document.getElementById('drink_volume');
   var percentageElement = document.getElementById('alcohol_percentage');
   var intakeElement = document.getElementById('alcohol_intake');
@@ -10,13 +10,7 @@ const calculateAndDisplayIntake = () => {
     intakeElement.textContent = intake.toFixed(2);
   };
 
+  calculateIntake();
   volumeElement.addEventListener('input', calculateIntake);
   percentageElement.addEventListener('input', calculateIntake);
-  calculateIntake();
-};
-
-document.addEventListener('DOMContentLoaded', () => {
-  document.addEventListener('turbo:load', calculateAndDisplayIntake);
 });
-
-export default calculateAndDisplayIntake;

--- a/app/javascript/controllers/record_form.js
+++ b/app/javascript/controllers/record_form.js
@@ -1,22 +1,19 @@
-// const formSwitch = () => {
-//   var selecterBox = document.getElementById('drink-details');
-//   var no_drink = document.getElementById('no-drink-radio');
-//   var drink = document.getElementById('drink-radio');
-//   var check = document.getElementsByClassName('js-check')
-//   var formDisplayChange = () => {
-//     if (check[1].checked) {
-//         selecterBox.style.display = "block";
-//     } else {
-//         selecterBox.style.display = "none";
-//     };
-//   };
-//   no_drink.addEventListener('click', formDisplayChange);
-//   drink.addEventListener('click', formDisplayChange);
-//   formDisplayChange();
-// };
+const formSwitch = () => {
+  var selecterBox = document.getElementById('drink-details');
+  var no_drink = document.getElementById('no-drink-radio');
+  var drink = document.getElementById('drink-radio');
+  var check = document.getElementsByClassName('js-check')
+  var formDisplayChange = () => {
+    if (check[1].checked) {
+        selecterBox.style.display = "block";
+    } else {
+        selecterBox.style.display = "none";
+    };
+  };
+  formDisplayChange();
+  no_drink.addEventListener('click', formDisplayChange);
+  drink.addEventListener('click', formDisplayChange);
+};
 
-// document.addEventListener('DOMContentLoaded', () => {
-//   document.addEventListener('turbo:load', formSwitch());
-// });
-
-// export default formSwitch;
+document.addEventListener('turbo:load', formSwitch);
+document.addEventListener('turbo:before-render', formSwitch);


### PR DESCRIPTION
## 概要
* 記録画面において、「休肝日」を選択した場合は詳細フォームを非表示に、「飲酒日」を選択した場合は詳細フォームを表示するようにJavaScriptを適用しました。
* あらかじめ「飲酒日」で登録してある記録を編集する場合に、「休肝日」に修正して登録した際には、自動的に詳細情報を「0」などに変更して登録できるようにしました。
## 確認方法
* 記録登録画面で詳細フォームが「休肝日」「飲酒日」の選択により非表示・表示が切り替わることを確認してください。
* 詳細フォームを登録した飲酒日の記録を編集する場合に、「休肝日」を選択して登録したときに、詳細情報が削除されていることを確認してください。