### PR TITLE
Add:飲酒記録の複数投稿機能

### DIFF
--- a/app/controllers/drink_records_controller.rb
+++ b/app/controllers/drink_records_controller.rb
@@ -21,12 +21,13 @@ class DrinkRecordsController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @drink_record_details = @drink_record.user.drink_records.where(start_time: @drink_record.start_time)
+  end
 
   def edit; end
 
   def update
-    binding.pry
     @drink_record.assign_attributes(drink_record_params)
     if @drink_record.save
       redirect_to drink_record_path(@drink_record), success: t('defaults.update_success')

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,8 +1,7 @@
 class ProfilesController < ApplicationController
-  before_action :set_user, only: [:edit, :update, :show]
+  before_action :set_user, only: %i[edit update show]
 
-  def edit
-  end
+  def edit; end
 
   def update
     user_params_with_days = user_params
@@ -17,7 +16,8 @@ class ProfilesController < ApplicationController
 
   def show
     start_date = params.fetch(:start_time, Date.today).to_date
-    @drink_record = @user.drink_records.all
+    drink_records = @user.drink_records.all
+    @display_records = drink_records.where(id: DrinkRecord.group(:start_time).select('MIN(id)'))
   end
 
   private

--- a/app/models/drink_record.rb
+++ b/app/models/drink_record.rb
@@ -2,7 +2,8 @@ class DrinkRecord < ApplicationRecord
   belongs_to :user
   has_one :post, dependent: :destroy
 
-  validates :user_id, presence: true, uniqueness: { scope: :start_time }
+  validates :user_id, presence: true, uniqueness: { scope: :start_time }, if: :record_type_is_no_drink?
+  validate :no_drink_and_drink_cannot_be_same_day, if: :record_type_is_drink?
   validates :record_type, presence: true
   validates :start_time, presence: true
   validates :drink_volume, numericality: { only_integer: true, equal_to: 0 }, if: :record_type_is_no_drink?
@@ -43,5 +44,11 @@ class DrinkRecord < ApplicationRecord
 
   def record_type_is_no_drink?
     record_type == 'no_drink'
+  end
+
+  def no_drink_and_drink_cannot_be_same_day
+    return unless DrinkRecord.where(user_id:, start_time:, record_type: 'no_drink').exists?
+
+    errors.add(:start_time, '同じ日に休肝日と飲酒日の両方は記録できません')
   end
 end

--- a/app/views/drink_records/_detail.html.erb
+++ b/app/views/drink_records/_detail.html.erb
@@ -1,0 +1,43 @@
+<% drink_record_details.each.with_index(1) do |drink_record_detail, i| %>
+  <div class="mx-8 border-b-2 font-semibold">詳細（その<%= i%>）</div>
+  <div class="m-8">
+    <div class="form-control mb-4 flex w-full flex-row items-center">
+      <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:drink_type) %></label>
+      <div class="font-semibold"><%= drink_record_detail.drink_type %></div>
+    </div>
+    <div class="form-control mb-4 flex w-full flex-row items-center">
+      <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:drink_volume) %></label>
+      <div class="flex flex-row items-center">
+        <div class="font-semibold"><%= drink_record_detail.drink_volume %></div>
+        <div class="ml-4 font-semibold">ml</div>
+      </div>
+    </div>
+    <div class="form-control mb-4 flex w-full flex-row items-center">
+      <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:alcohol_percentage) %></label>
+      <div class="flex flex-row items-center">
+        <div class="font-semibold"><%= drink_record_detail.alcohol_percentage %></div>
+        <div class="ml-4 font-semibold">%</div>
+      </div>
+    </div>
+    <div class="form-control mb-4 flex w-full flex-row items-center">
+      <label class="label mr-8 w-44 font-semibold"><%= t 'defaults.amount_of_alcohol' %></label>
+      <div class="flex flex-row items-center">
+        <div class="font-semibold"><%= alcohol_caluculate(drink_record_detail.drink_volume, drink_record_detail.alcohol_percentage) %></div>
+        <div class="ml-4 font-semibold">g</div>
+      </div>
+    </div>
+    <div class="form-control mb-4 flex w-full flex-row items-center">
+      <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:price) %></label>
+      <div class="flex flex-row items-center">
+        <div class="font-semibold"><%= drink_record_detail.price %></div>
+        <div class="ml-4 font-semibold">円</div>
+      </div>
+    </div>
+  </div>
+  <% if drink_record_detail.user == current_user %>
+    <div class="card-actions justify-end mx-8 mb-4">
+      <%= link_to t('defaults.edit'), edit_drink_record_path(drink_record_detail), class: "btn btn-primary" %>
+      <%= link_to t('defaults.delete'), drink_record_path(drink_record_detail), class: "btn btn-accent", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") } %>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/drink_records/_form.html.erb
+++ b/app/views/drink_records/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: drink_record, local: true do |f| %>
   <div class="flex flex-col items-center justify-evenly md:flex-row md:content-evenly">
-    <%= f.radio_button :record_type, "no_drink", class: "btn btn-primary btn-outline join-item m-4 px-12 js-check", "aria-label": :"休肝日", id: "no-drink-radio" %>
-    <%= f.radio_button :record_type, "drink", class: "btn btn-secondary btn-outline join-item m-4 px-12 js-check", "aria-label": :"飲酒日" , id: "drink-radio" %>
+    <%= f.radio_button :record_type, "no_drink", class: "btn btn-outline btn-primary join-item m-4 px-12 js-check", "aria-label": :"休肝日", id: "no-drink-radio" %>
+    <%= f.radio_button :record_type, "drink", class: "btn btn-outline btn-secondary join-item m-4 px-12 js-check", "aria-label": :"飲酒日" , id: "drink-radio" %>
   </div>
   <div class="md:p-8 p-4">
     <div class="form-control mb-4 flex w-full flex-row items-center">
@@ -9,7 +9,11 @@
       <% if drink_record.start_time.present? %>
         <%= f.date_field :start_time, class: "input input-bordered w-full max-w-xs", value: drink_record.start_time.strftime("%Y-%m-%d") %>
       <% else %>
-        <%= f.date_field :start_time, class: "input input-bordered w-full max-w-xs", value: Date.today.strftime("%Y-%m-%d") %>
+        <% if params[:record_id].present? %>
+          <%= f.date_field :start_time, class: "input input-bordered w-full max-w-xs", value: DrinkRecord.find(params[:record_id]).start_time.strftime("%Y-%m-%d") %>
+        <% else %>
+          <%= f.date_field :start_time, class: "input input-bordered w-full max-w-xs", value: Date.today.strftime("%Y-%m-%d") %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/drink_records/show.html.erb
+++ b/app/views/drink_records/show.html.erb
@@ -13,51 +13,20 @@
         <div class="btn btn-secondary btn-active btn-outline join-item m-4 px-12" type="radio" name="drink_record[:record_type]"><%= t 'defaults.alcohol_day' %></div>
       <% end %>
     </div>
-    <div class="mx-8 border-b-2 font-semibold">詳細</div>
-    <div class="m-8">
+    <div class="md:p-8 p-4">
       <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:start_time) %></label>
+        <label class="label md:mr-8 md:w-44 mr-4 w-24"><%= DrinkRecord.human_attribute_name(:start_time) %></label>
         <div class="font-semibold"><%= @drink_record.start_time.strftime("%Y年 %m月 %d日(%a)") %></div>
       </div>
-      <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:drink_type) %></label>
-        <div class="font-semibold"><%= @drink_record.drink_type %></div>
-      </div>
-      <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:drink_volume) %></label>
-        <div class="flex flex-row items-center">
-          <div class="font-semibold"><%= @drink_record.drink_volume %></div>
-          <div class="ml-4 font-semibold">ml</div>
-        </div>
-      </div>
-      <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:alcohol_percentage) %></label>
-        <div class="flex flex-row items-center">
-          <div class="font-semibold"><%= @drink_record.alcohol_percentage %></div>
-          <div class="ml-4 font-semibold">%</div>
-        </div>
-      </div>
-      <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44 font-semibold"><%= t 'defaults.amount_of_alcohol' %></label>
-        <div class="flex flex-row items-center">
-          <div class="font-semibold"><%= alcohol_caluculate(@drink_record.drink_volume, @drink_record.alcohol_percentage) %></div>
-          <div class="ml-4 font-semibold">g</div>
-        </div>
-      </div>
-      <div class="form-control mb-4 flex w-full flex-row items-center">
-        <label class="label mr-8 w-44"><%= DrinkRecord.human_attribute_name(:price) %></label>
-        <div class="flex flex-row items-center">
-          <div class="font-semibold"><%= @drink_record.price %></div>
-          <div class="ml-4 font-semibold">円</div>
-        </div>
-      </div>
-      <% if @drink_record.user == current_user %>
-        <div class="card-actions justify-end">
-          <%= link_to t('defaults.edit'), edit_drink_record_path, class: "btn btn-primary" %>
-          <%= link_to t('defaults.delete'), drink_record_path, class: "btn btn-accent", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") } %>
-        </div>
-      <% end %>
     </div>
+    <% if @drink_record.user == current_user %>
+      <div class="card-actions justify-end mx-8 mb-4">
+        <% if @drink_record.drink? %>
+          <%= link_to t('defaults.add_record'), new_drink_record_path(record_id: @drink_record.id), class: "btn btn-outline btn-secondary" %>
+        <% end %>
+      </div>
+    <% end %>
+    <%= render 'detail', drink_record_details: @drink_record_details %>
   </div>
 </div>
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -47,7 +47,7 @@
   <div class="card rounded-box flex-grow bg-white shadow-xl md:w-2/3">
     <div class="flex w-full flex-col p-4">
       <div class="card rounded-box grid place-items-center bg-base-300">
-        <%= month_calendar(events: @drink_record) do |date, drink_record| %>
+        <%= month_calendar(events: @display_records) do |date, drink_record| %>
           <div><%= date.day %></div>
           <% drink_record.each do |record| %>
             <% if record.no_drink? %>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -16,6 +16,7 @@ ja:
     contact: 'お問い合わせ'
     register: '登録'
     detail: '詳細'
+    add_record: '飲酒記録を追加'
     edit: '編集'
     delete: '削除'
     no_alcohol_day: '休肝日'


### PR DESCRIPTION
## 概要
- 同日に飲酒記録の詳細は複数投稿可能としました。

## 確認方法
- 同日に「休肝日」を登録できる回数は1回のみのままとなっていることを確認してください。
- 同日に「休肝日」と「飲酒日」の2つを登録するのはできないことを確認してください。
- 同日に「飲酒日」として、飲酒記録の詳細が複数投稿できることを確認してください。
- 「飲酒日」の詳細ページから「飲酒記録を追加」ボタンから新たに登録できることを確認してください。また、「休肝日」の詳細ページにおいてはボタンが表示されていないことを確認してください。
- 複数登録した日の「飲酒日」記録の詳細画面において、登録した詳細がそれぞれ表示されていることを確認してください。

## 影響範囲

- 記録詳細画面の飲酒の詳細情報については、パーシャル処理としました。