### PR TITLE
Add:コミュニティ機能の追加（ポストの一覧表示）

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -103,4 +103,10 @@
   .bg-opacity-for-topimage {
     background-color: rgba(255, 255, 255, 0.6);
   }
+
+  .tab:is(input[type=radio]) {
+    width: max-content;
+    border-bottom-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
 }

--- a/app/controllers/community_posts_controller.rb
+++ b/app/controllers/community_posts_controller.rb
@@ -1,0 +1,36 @@
+class CommunityPostsController < ApplicationController
+  skip_before_action :require_login, only: %i[index show]
+  skip_before_action :require_general, only: %i[index show]
+  before_action :set_user, only: %i[index new create edit update destroy]
+
+  def index
+    @community_posts = CommunityPost.all
+  end
+
+  def new
+  end
+
+  def create
+  end
+
+  def show
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def destroy
+  end
+
+  private
+  def set_user
+    if logged_in?
+      @user = current_user
+    else
+      @user = nil
+    end
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -18,6 +18,7 @@ class ProfilesController < ApplicationController
     start_date = params.fetch(:start_time, Date.today).to_date
     drink_records = @user.drink_records.all
     @display_records = drink_records.where(id: drink_records.group(:start_time).select('MIN(id)'))
+    @community_posts = CommunityPost.all
   end
 
   private

--- a/app/helpers/community_posts_helper.rb
+++ b/app/helpers/community_posts_helper.rb
@@ -1,0 +1,2 @@
+module CommunityPostsHelper
+end

--- a/app/models/community_post.rb
+++ b/app/models/community_post.rb
@@ -1,0 +1,6 @@
+class CommunityPost < ApplicationRecord
+  belongs_to :user
+
+  validates :content, presence: true, length: { maximum: 256 }
+  validates :user_id, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,7 @@ class User < ApplicationRecord
   has_many :post_likes, dependent: :destroy
   has_many :liked_posts, through: :post_likes, source: :post
   accepts_nested_attributes_for :authentications
+  has_many :community_posts, dependent: :destroy
 
   validates :username, presence: true
   validates :comment, length: { maximum: 256 }

--- a/app/views/community_posts/_posts.html.erb
+++ b/app/views/community_posts/_posts.html.erb
@@ -1,6 +1,6 @@
-<% if group.posts.present? %>
-  <% group.posts.each do |post| %>
-    <%= link_to group_post_path(group, post), class: "flex flex-row card rounded-box bg-white shadow-xl w-full mb-4 p-4", id: "post-#{post.id}" do %>
+<% if posts.present? %>
+  <% posts.each do |post| %>
+    <%= link_to community_post_path(post), class: "flex flex-row card rounded-box bg-white shadow-xl w-full mb-4 p-4", id: "community-post-#{post.id}" do %>
       <div class="avatar">
         <div class="h-12 w-12 rounded-full">
           <%= image_tag post.user.image %>
@@ -9,7 +9,7 @@
       <div class="pl-6">
         <div class="flex flex-row">
           <div class="font-bold"><%= post.user.username %></div>
-          <div class="ml-4 text-neutral-300">記録日: <%= post.drink_record.start_time.strftime("%F") %></div>
+          <div class="ml-4 text-neutral-300">作成日: <%= post.created_at.strftime("%F") %></div>
         </div>
         <div class="text-neutral-900"><%= post.content %></div>
       </div> 
@@ -18,7 +18,7 @@
 <% else %>
   <div class="card rounded-box bg-white shadow-xl w-full mt-4 p-4">
     <div class="pl-6">
-      <%= t '.no_post' %>
+      <%= t 'defaults.no_post' %>
     </div>
   </div>
 <% end %>

--- a/app/views/community_posts/edit.html.erb
+++ b/app/views/community_posts/edit.html.erb
@@ -1,0 +1,2 @@
+<h1>CommunityPosts#edit</h1>
+<p>Find me in app/views/community_posts/edit.html.erb</p>

--- a/app/views/community_posts/index.html.erb
+++ b/app/views/community_posts/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for(:title, t(".title")) %>
+<div class="w-6xl flex-auto">
+  <div class="flex flex-col p-4 max-w-6xl mx-auto">
+    <h2 class="title-font text-lg font-semibold"><%= t '.title' %></h2>
+    <% if @user.present? %>
+    <div class="card rounded-box flex-grow place-items-center bg-white shadow-xl">
+      <div class="w-full px-4">
+        <div class="flex flex-row items-center justify-center text-left md:justify-start md:text-left">
+          <div class="flex flex-row flex-auto items-center pl-2 text-left md:text-left">
+            <div class="avatar">
+              <div class="h-12 w-12 rounded-full">
+                <%= image_tag @user.image %>
+              </div>
+            </div>
+            <div class="pl-6">
+              <h2 class="title-font font-semibold"><%= @user.username %></h2>
+            </div>
+          </div>
+          <div class="py-4 pl-4 flex-initial">
+            <%= link_to t('defaults.my_page'), profile_path, class: "btn btn-primary" %>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="divider"></div>
+    <% end %>
+    <div class="flex-grow">
+      <%= render partial: 'community_posts/posts', locals: { posts: @community_posts } %>
+    </div>
+  </div>
+  <% if logged_in? %>
+    <% if @user.general? || @user.admin? %>
+      <%= link_to t(".post"), new_community_post_path, class: "btn btn-outline btn-accent fixed md:right-1/4 right-4" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/community_posts/new.html.erb
+++ b/app/views/community_posts/new.html.erb
@@ -1,0 +1,2 @@
+<h1>CommunityPosts#new</h1>
+<p>Find me in app/views/community_posts/new.html.erb</p>

--- a/app/views/community_posts/show.html.erb
+++ b/app/views/community_posts/show.html.erb
@@ -1,0 +1,2 @@
+<h1>CommunityPosts#show</h1>
+<p>Find me in app/views/community_posts/show.html.erb</p>

--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -67,7 +67,7 @@
   </div>
   <div class="divider md:divider-horizontal"></div>
   <div class="flex flex-col md:w-2/3">
-    <div class="card rounded-box flex-col bg-white shadow-xl max-w-full">
+    <div class="card rounded-box flex-col bg-white shadow-xl max-w-full mb-4">
       <div class="flex w-full flex-col p-4">
         <div class="card rounded-box grid">
           <h2 class="text-xl font-semibold text-center"><%= t 'defaults.record' %></h2>

--- a/app/views/profiles/_groups.html.erb
+++ b/app/views/profiles/_groups.html.erb
@@ -1,3 +1,3 @@
 <% user.groups.each do |group| %>
-  <%= link_to group.name, group_path(group),class: "btn btn-neutral-100 w-full", data: { turbo: false } %>
+  <%= link_to group.name, group_path(group),class: "btn btn-accent-content w-full mb-4", data: { turbo: false } %>
 <% end %>

--- a/app/views/profiles/_record_calendar.html.erb
+++ b/app/views/profiles/_record_calendar.html.erb
@@ -1,0 +1,20 @@
+<div class="card rounded-box bg-white shadow-xl w-full">
+  <div class="flex w-full flex-col p-4">
+    <div class="card rounded-box grid place-items-center bg-base-300">
+      <%= month_calendar(events: display_records) do |date, drink_record| %>
+        <div><%= date.day %></div>
+        <% drink_record.each do |record| %>
+          <% if record.no_drink? %>
+            <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-primary md:btn-sm lg:btn-md text-tiny", data: { turbo: false } %>
+          <% elsif record.drink? %>
+            <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-secondary md:btn-sm lg:btn-md text-tiny", data: { turbo: false } %>
+          <% end %>
+        <% end %>
+      <% end %>
+    </div>
+    <div class="flex flex-col justify-evenly md:flex-row md:content-evenly">
+      <%= link_to '休肝日・飲酒日を記録', new_drink_record_path, class:"btn btn-accent m-4", data: { turbo: false } %>
+    </div>
+    <div class="card rounded-box grid h-20 place-items-center bg-base-300 hidden">content</div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,16 +1,16 @@
 <% content_for(:title, t(".title")) %>
-<div class="flex flex-col p-4 md:flex-row md:p-8 flex-auto max-w-6xl mx-auto">
-  <div class="card rounded-box flex-grow place-items-center bg-white shadow-xl md:w-1/3">
-    <div class="w-full p-4">
-      <div class="h-full flex-row items-center justify-center text-left md:justify-start md:text-left">
-        <div class="flex flex-row items-center pl-2 text-left md:text-left">
-          <div class="avatar">
-            <div class="h-24 w-24 rounded-full">
-              <%= image_tag @user.image %>
+<div class="w-6xl flex-auto">
+  <div class="flex flex-col p-4 md:flex-row md:p-8 max-w-6xl mx-auto">
+    <div class="card rounded-box flex-grow place-items-center bg-white shadow-xl md:w-1/3">
+      <div class="w-full p-4">
+        <div class="h-full flex-row items-center justify-center text-left md:justify-start md:text-left">
+          <div class="flex flex-row items-center pl-2 text-left md:text-left">
+            <div class="avatar">
+              <div class="h-24 w-24 rounded-full">
+                <%= image_tag @user.image %>
+              </div>
             </div>
-          </div>
-          <div class="pl-6">
-            <div>
+            <div class="pl-6">
               <h2 class="title-font text-xl font-semibold text-neutral-900"><%= @user.username %></h2>
               <p><%= t '.no_alcohol_day' %></p>
               <% @user.non_drinking_days.each do |index| %>
@@ -18,50 +18,42 @@
               <% end %>
             </div>
           </div>
-        </div>
-        <div class="flex-grow py-4 pl-4">
-          <p><%= @user.comment %></p>
-          <div class="text-right">
-            <%= link_to (t 'profiles.edit.title'), edit_profile_path, class:"link text-xs", id:"edit-profile" %>
-          </div>
-        </div>
-        <div class="w-full">
-          <p class="title-font text-xl font-semibold text-neutral-900"><%= t 'defaults.group' %></p>
-          <% if @user.groups.present? %>
-            <%= render partial: 'profiles/groups', locals: { user: @user } %>
-          <% else %>
-            <div class="btn-neutral-100 btn btn-active w-full">
-              <%= t '.no_group' %>
+          <div class="flex-grow py-4 pl-4">
+            <p><%= @user.comment %></p>
+            <div class="text-right">
+              <%= link_to (t 'profiles.edit.title'), edit_profile_path, class:"link text-xs", id:"edit-profile" %>
             </div>
-          <% end %>
-          <div class="text-right">
-            <%= link_to t('.create_group'), new_group_path, class: "link text-xs", data: { turbo: false }, id: "new-group" %>
           </div>
+          <div class="w-full">
+            <p class="title-font text-xl font-semibold text-neutral-900"><%= t 'defaults.group' %></p>
+            <% if @user.groups.present? %>
+              <%= render partial: 'profiles/groups', locals: { user: @user } %>
+            <% else %>
+              <div class="btn-neutral-100 btn btn-active w-full">
+                <%= t '.no_group' %>
+              </div>
+            <% end %>
+            <div class="text-right">
+              <%= link_to t('.create_group'), new_group_path, class: "link text-xs", data: { turbo: false }, id: "new-group" %>
+            </div>
+          </div>
+          <div class="title-font text-xl font-semibold text-neutral-900"><%= t 'defaults.record' %></div>
+          <%= render 'shared/drink_record_summary', { user: @user } %>
         </div>
-        <div class="title-font text-xl font-semibold text-neutral-900"><%= t 'defaults.record' %></div>
-        <%= render 'shared/drink_record_summary', { user: @user } %>
       </div>
     </div>
-  </div>
-  <div class="divider md:divider-horizontal"></div>
-  <div class="card rounded-box flex-grow bg-white shadow-xl md:w-2/3">
-    <div class="flex w-full flex-col p-4">
-      <div class="card rounded-box grid place-items-center bg-base-300">
-        <%= month_calendar(events: @display_records) do |date, drink_record| %>
-          <div><%= date.day %></div>
-          <% drink_record.each do |record| %>
-            <% if record.no_drink? %>
-              <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-primary md:btn-sm lg:btn-md text-tiny", data: { turbo: false } %>
-            <% elsif record.drink? %>
-              <%= link_to record.record_type_i18n, drink_record_path(record), class:"btn btn-xs btn-secondary md:btn-sm lg:btn-md text-tiny", data: { turbo: false } %>
-            <% end %>
-          <% end %>
-        <% end %>
+    <div class="divider md:divider-horizontal"></div>
+    <div class="flex-grow md:w-2/3">
+      <div role="tablist" class="tabs tabs-bordered">
+        <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="カレンダー" checked/>
+        <div role="tabpanel" class="tab-content">
+          <%= render partial: 'profiles/record_calendar', locals: { display_records: @display_records } %>
+        </div>
+        <input type="radio" name="my_tabs_1" role="tab" class="tab" aria-label="コミュニティポスト"/>
+        <div role="tabpanel" class="tab-content">
+          <%= render partial: 'community_posts/posts', locals: { posts: @community_posts } %>
+        </div>
       </div>
-      <div class="flex flex-col justify-evenly md:flex-row md:content-evenly">
-        <%= link_to '休肝日・飲酒日を記録', new_drink_record_path, class:"btn btn-accent m-4", data: { turbo: false } %>
-      </div>
-      <div class="card rounded-box grid h-20 place-items-center bg-base-300 hidden">content</div>
     </div>
   </div>
 </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -4,8 +4,8 @@
   </div>
   <div class="navbar-end">
     <ul class="menu menu-horizontal invisible px-1 md:visible">
-      <li><a><%= t 'defaults.top_page' %></a></li>
-      <li><a><%= t 'defaults.community' %></a></li>
+      <li><%= link_to t('defaults.top_page'), root_path %></li>
+      <li><%= link_to t('defaults.community'), community_posts_path %></li>
     </ul>
     <%= link_to auth_at_provider_path(provider: :line), class: "inline-block" do %>
         <%= image_tag "btn_login_base.png" %>
@@ -17,8 +17,8 @@
         <i class="fa fa-bars"></i> 
       </label>
       <ul tabindex="0" class="mt-3 z-[1] p-2 shadow menu menu-sm dropdown-content bg-base-100 rounded-box w-32">
-        <li><a><%= t 'defaults.top_page' %></a></li>
-        <li><a><%= t 'defaults.community' %></a></li>
+        <li><%= link_to t('defaults.top_page'), root_path %></li>
+        <li><%= link_to t('defaults.community'), community_posts_path %></li>
       </ul>
     </div>
   </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="footer items-center p-4 bg-gradient-to-r from-primary to-secondary text-neutral-content">
+<footer class="footer items-center p-4 bg-gradient-to-r from-primary to-secondary text-neutral-content z-10">
   <aside class="items-center grid-flow-col">
     <p>Copyright © 2024 肝ログ All right reserved</p>
   </aside> 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -11,7 +11,7 @@
       <li><%= link_to t('defaults.explanation'), root_path %></li>
     </ul>
     <ul class="menu menu-horizontal invisible px-1 md:visible">
-      <li><a><%= t 'defaults.community' %></a></li>
+      <li><%= link_to t('defaults.community'), community_posts_path %></li>
     </ul>
     <% if current_user.general? || current_user.admin? %>
       <%= link_to t('defaults.record'), new_drink_record_path, class: 'btn btn-accent', data: { turbo: false } %>
@@ -57,7 +57,9 @@
               </ul>
             </li>
           <% end %>
-          <li class="md:hidden"><a><%= t 'defaults.community' %></a></li>
+          <li class="md:hidden">
+            <li><%= link_to t('defaults.community'), community_posts_path %></li>
+          </li>
           <li class="md:hidden">
             <%= link_to t('defaults.explanation'), root_path %>
           </li>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -29,6 +29,7 @@ ja:
     update_success: '記録を更新しました'
     access_denied: 'アクセス権限がありません'
     post: '投稿'
+    no_post: 'まだ投稿がありません'
     comment_success: 'コメントしました'
     comment_error: 'コメントに失敗しました'
     comment_delete: 'コメントを削除しました'
@@ -100,6 +101,11 @@ ja:
     show:
       title: 'ポスト'
       no_alcohol_day: '休肝日'
+  community_posts:
+    index:
+      title: 'コミュニティ'
+      no_post: '投稿なし'
+      post: 'ポストする'
   invitees:
     invitation:
       new:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
   get 'first_login', to: 'static_pages#first_login'
   patch 'first_login', to: 'static_pages#update'
   put 'first_login', to: 'static_pages#update'
-  # resources :users, only: [:edit, :update, :show]
   resource :profile, only: %i[edit update show]
   resources :drink_records, only: %i[new create show edit update destroy]
   resources :groups, only: %i[new create show edit update destroy] do
@@ -17,6 +16,7 @@ Rails.application.routes.draw do
       end
     end
   end
+  resources :community_posts
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'

--- a/db/migrate/20240205134247_create_community_posts.rb
+++ b/db/migrate/20240205134247_create_community_posts.rb
@@ -1,0 +1,11 @@
+class CreateCommunityPosts < ActiveRecord::Migration[7.0]
+  def change
+    create_table :community_posts do |t|
+      t.text :content, null: false
+      t.string :image
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_18_154852) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_05_134247) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,15 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_154852) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "community_posts", force: :cascade do |t|
+    t.text "content", null: false
+    t.string "image"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_community_posts_on_user_id"
   end
 
   create_table "drink_records", force: :cascade do |t|
@@ -99,6 +108,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_18_154852) do
     t.integer "non_drinking_days", default: [], array: true
   end
 
+  add_foreign_key "community_posts", "users"
   add_foreign_key "drink_records", "users"
   add_foreign_key "groups", "users", column: "group_admin_id"
   add_foreign_key "post_comments", "posts"

--- a/lib/tasks/line_summary_push.rake
+++ b/lib/tasks/line_summary_push.rake
@@ -15,7 +15,8 @@ namespace :line_summary_push do
     end
 
     def week_summary(user)
-      user.drink_records.where(start_time: Date.today.prev_week.beginning_of_week..Date.today.prev_week.end_of_week)
+      drnik_records = user.drink_records.where(start_time: Date.today.prev_week.beginning_of_week..Date.today.prev_week.end_of_week)
+      drink_records.where(id: drink_records.group(:start_time).select('MIN(id)'))
     end
 
     def week_total_amount_alcohol(user)

--- a/spec/factories/community_posts.rb
+++ b/spec/factories/community_posts.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :community_post do
+    content { "MyText" }
+    image { "MyString" }
+    user { nil }
+  end
+end

--- a/spec/helpers/community_posts_helper_spec.rb
+++ b/spec/helpers/community_posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommunityPostsHelper. For example:
+#
+# describe CommunityPostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommunityPostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/community_post_spec.rb
+++ b/spec/models/community_post_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CommunityPost, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/community_posts_spec.rb
+++ b/spec/requests/community_posts_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe "CommunityPosts", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/community_posts/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/community_posts/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/community_posts/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/community_posts/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/community_posts/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /update" do
+    it "returns http success" do
+      get "/community_posts/update"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/community_posts/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/community_posts/create.html.erb_spec.rb
+++ b/spec/views/community_posts/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_posts/destroy.html.erb_spec.rb
+++ b/spec/views/community_posts/destroy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/destroy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_posts/edit.html.erb_spec.rb
+++ b/spec/views/community_posts/edit.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/edit.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_posts/index.html.erb_spec.rb
+++ b/spec/views/community_posts/index.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/index.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_posts/new.html.erb_spec.rb
+++ b/spec/views/community_posts/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/new.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_posts/show.html.erb_spec.rb
+++ b/spec/views/community_posts/show.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/show.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_posts/update.html.erb_spec.rb
+++ b/spec/views/community_posts/update.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_posts/update.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- コミュニティ機能を追加しました（一覧表示）。
- 機能実装のために`CommunityPost`モデルと`community_posts`コントローラを作成し、ルーティングを行いました。
- コミュニティへ投稿されたポストを一覧表示するページを作成しました。
## 確認方法
- ログイン前のトップページでヘッダーの「コミュニティ」リンクからコミュニティ投稿一覧ページに遷移することを確認してください。
- ログイン後、コミュニティ投稿一覧ページにおいて、ログインユーザのプロフィールと「ポストする」ボタンが表示されていないことを確認してください。
## コメント
- モデルの細かなバリデーションなどは追々機能を追加していく段階で作成します。