### PR TITLE
Add:コミュニティポストに対するコメント・いいね機能の追加

### DIFF
--- a/app/controllers/community_post_comments_controller.rb
+++ b/app/controllers/community_post_comments_controller.rb
@@ -1,0 +1,24 @@
+class CommunityPostCommentsController < ApplicationController
+  skip_before_action :require_general, only: %i[create destroy]
+
+  def create
+    comment = current_user.community_post_comments.new(community_post_comment_params)
+    if comment.save
+      redirect_to community_post_path(comment.community_post), success: t('defaults.comment_success')
+    else
+      redirect_to community_post_path(comment.community_post), danger: t('defaults.comment_error')
+    end
+  end
+
+  def destroy
+    comment = CommunityPostComment.find(params[:id])
+    comment.destroy!
+    redirect_to community_post_path(comment.community_post), success: t('defaults.comment_delete')
+  end
+
+  private
+
+  def community_post_comment_params
+    params.require(:community_post_comment).permit(:message).merge(community_post_id: params[:community_post_id])
+  end
+end

--- a/app/controllers/community_post_likes_controller.rb
+++ b/app/controllers/community_post_likes_controller.rb
@@ -1,0 +1,15 @@
+class CommunityPostLikesController < ApplicationController
+  skip_before_action :require_general, only: %i[create destroy]
+
+  def create
+    post = CommunityPost.find params[:community_post_id]
+    current_user.like_community_post(post)
+    redirect_to community_post_path(params[:community_post_id]), success: t('defaults.like_post')
+  end
+
+  def destroy
+    post = CommunityPost.find params[:community_post_id]
+    current_user.unlike_community_post(post)
+    redirect_to community_post_path(params[:community_post_id]), success: t('defaults.unlike_post')
+  end
+end

--- a/app/controllers/community_posts_controller.rb
+++ b/app/controllers/community_posts_controller.rb
@@ -23,7 +23,10 @@ class CommunityPostsController < ApplicationController
     end
   end
 
-  def show; end
+  def show
+    @community_post_comment = CommunityPostComment.new
+    @community_post_comments = @community_post.community_post_comments.includes(:user).order(created_at: :desc)
+  end
 
   def edit
     authorize_user(@community_post, @user)

--- a/app/helpers/community_post_comments_helper.rb
+++ b/app/helpers/community_post_comments_helper.rb
@@ -1,0 +1,2 @@
+module CommunityPostCommentsHelper
+end

--- a/app/helpers/community_post_likes_helper.rb
+++ b/app/helpers/community_post_likes_helper.rb
@@ -1,0 +1,2 @@
+module CommunityPostLikesHelper
+end

--- a/app/models/community_post.rb
+++ b/app/models/community_post.rb
@@ -1,5 +1,7 @@
 class CommunityPost < ApplicationRecord
   belongs_to :user
+  has_many :community_post_likes, dependent: :destroy
+  has_many :community_post_comments, dependent: :destroy
 
   validates :content, presence: true, length: { maximum: 256 }
   validates :user_id, presence: true

--- a/app/models/community_post_comment.rb
+++ b/app/models/community_post_comment.rb
@@ -1,0 +1,6 @@
+class CommunityPostComment < ApplicationRecord
+  belongs_to :user
+  belongs_to :community_post
+
+  validates :message, presence: true, length: { maximum: 256 }
+end

--- a/app/models/community_post_like.rb
+++ b/app/models/community_post_like.rb
@@ -1,0 +1,6 @@
+class CommunityPostLike < ApplicationRecord
+  belongs_to :user
+  belongs_to :community_post
+
+  validates :user_id, uniqueness: { scope: :community_post_id }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,9 @@ class User < ApplicationRecord
   has_many :liked_posts, through: :post_likes, source: :post
   accepts_nested_attributes_for :authentications
   has_many :community_posts, dependent: :destroy
+  has_many :community_post_comments, dependent: :destroy
+  has_many :community_post_likes, dependent: :destroy
+  has_many :liked_community_posts, through: :community_post_likes, source: :community_post
 
   validates :username, presence: true
   validates :comment, length: { maximum: 256 }
@@ -109,6 +112,18 @@ class User < ApplicationRecord
 
   def own?(object)
     id == object.user_id
+  end
+
+  def like_community_post(community_post)
+    liked_community_posts << community_post
+  end
+
+  def unlike_community_post(community_post)
+    liked_community_posts.delete(community_post)
+  end
+
+  def like_community_post?(community_post)
+    liked_community_posts.include?(community_post)
   end
 
   private

--- a/app/views/community_post_comments/_comments.html.erb
+++ b/app/views/community_post_comments/_comments.html.erb
@@ -1,0 +1,7 @@
+<div class="flex flex-row">
+  <div class="w-full p-4 rounded break-words border bg-white border-gray-300">
+    <table id="js-table-comment" class="w-full max-w-full bg-transparent">
+      <%= render comments %>
+    </table>
+  </div>
+</div>

--- a/app/views/community_post_comments/_community_post_comment.html.erb
+++ b/app/views/community_post_comments/_community_post_comment.html.erb
@@ -1,0 +1,27 @@
+<tr id="comment-<%= community_post_comment.id %>">
+  <td style="width: 60px">
+    <div class="avatar">
+      <div class="h-12 w-12 rounded-full">
+        <%= image_tag community_post_comment.user.image %>
+      </div>
+    </div>
+  </td>
+  <td>
+    <h3 class="text-sm font-semibold"><%= community_post_comment.user.username %></h3>
+    <div id="js-comment-<%= community_post_comment.id %>">
+      <div class="text-neutral-900"><%= community_post_comment.message %></div>
+    </div>
+  </td>
+
+  <% if current_user.own?(community_post_comment) %>
+    <td class="action">
+      <ul class="list-inline justify-center" style="float: right;">
+        <li class="list-inline-item">
+          <%= link_to community_post_comment_path(community_post_comment), class: 'js-edit-comment-button', id: "delete-comment-#{community_post_comment.id}", data: { turbo_method: :delete, confirm: t("defaults.delete_confirm") } do %>
+            <i class="fa-solid fa-trash-can"></i>
+          <% end %>
+        </li>
+      </ul>
+    </td>
+  <% end %>
+</tr>

--- a/app/views/community_post_comments/_form.html.erb
+++ b/app/views/community_post_comments/_form.html.erb
@@ -1,0 +1,14 @@
+<div class="flex flex-row mb-3 w-full rounded break-words border bg-white border-gray-300">
+  <div class="p-4 w-full">
+    <%= form_with model: [community_post, comment], local: true do |f| %>
+      <%= render 'shared/error_messages', { object: f.object } %>
+      <div class="form-control">
+        <%= f.label :message, class: 'label' %>
+      </div>
+      <div class="form-control">
+        <%= f.text_area :message, class: 'textarea textarea-bordered max-w-full mb-3', id: 'js-new-comment-body', placeholder: CommunityPostComment.human_attribute_name(:message) %>
+      </div>
+      <%= f.submit t('defaults.post'), class: 'btn btn-primary' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/community_posts/_like.html.erb
+++ b/app/views/community_posts/_like.html.erb
@@ -1,0 +1,3 @@
+<%= link_to community_post_likes_path(community_post_id: community_post.id), id: "button-like-#{community_post.id}", data: { turbo_method: :post } do %>
+  <i class="fa-regular fa-thumbs-up fa-lg"></i>
+<% end %>

--- a/app/views/community_posts/_like_btn.html.erb
+++ b/app/views/community_posts/_like_btn.html.erb
@@ -1,0 +1,11 @@
+<div class="divider"></div>
+<ul class='crud-menu-btn list-none'>
+  <li class="inline-block mr-4">
+    <% if current_user.like_community_post?(community_post) %>
+      <%= render 'community_posts/unlike', { community_post: community_post } %>
+    <% else %>
+      <%= render 'community_posts/like', { community_post: community_post } %>
+    <% end %>
+    <%= t('defaults.likes') %>:<%= community_post.community_post_likes.count %>
+  </li>
+</ul> 

--- a/app/views/community_posts/_unlike.html.erb
+++ b/app/views/community_posts/_unlike.html.erb
@@ -1,0 +1,3 @@
+<%= link_to community_post_like_path(community_post_id: community_post.id), id: "button-like-#{community_post.id}", data: { turbo_method: :delete } do %>
+  <i class="fa-solid fa-thumbs-up fa-lg"></i>
+<% end %>

--- a/app/views/community_posts/show.html.erb
+++ b/app/views/community_posts/show.html.erb
@@ -42,23 +42,23 @@
             <ul class="list-none">
               <li class="inline-block mr-2 text-neutral-300">投稿日: <%= @community_post.created_at.strftime('%Y年%m月%d日') %></li>
             </ul>
-            <%# <%= render 'shared/like_btn', { post: @community_post } %> %>
+            <%= render 'community_posts/like_btn', { community_post: @community_post } %>
           </div>
         </article>
       </div>
     </div>
 
     <!-- コメントフォーム -->
-    <%# <div class="px-4"> %>
-      <%# <%= render 'post_comments/form', { group: @group, post: @post, comment: @post_comment } %> %>
-    <%# </div> %>
+    <div class="px-4">
+      <%= render 'community_post_comments/form', { community_post: @community_post, comment: @community_post_comment } %>
+    </div>
 
     <!-- コメントエリア -->
-    <%# <% if @post_comments.present? %> %>
-      <%# <div class="divider"></div> %>
-      <%# <div class="px-4"> %>
-        <%# <%= render 'post_comments/comments', { comments: @post_comments } %> %>
-      <%# </div> %>
-    <%# <% end %> %>
+    <% if @community_post_comments.present? %>
+      <div class="divider"></div>
+      <div class="px-4">
+        <%= render 'community_post_comments/comments', { comments: @community_post_comments } %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -30,6 +30,10 @@ ja:
         user_id: 'ユーザーID'
         content: '内容'
         image: '画像'
+      community_post_comment:
+        user_id: 'ユーザーID'
+        community_post_id: 'コミュニティポストID'
+        message: 'コメント'
   enums:
     drink_record:
       record_type:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,13 +10,18 @@ Rails.application.routes.draw do
   resources :drink_records, only: %i[new create show edit update destroy]
   resources :groups, only: %i[new create show edit update destroy] do
     resources :posts, only: %i[create show] do
-      resources :post_comments, only: %i[create show destroy], shallow: true
+      resources :post_comments, only: %i[create destroy], shallow: true
       member do
         resources :likes, only: %i[create destroy]
       end
     end
   end
-  resources :community_posts
+  resources :community_posts do
+    resources :community_post_comments, only: %i[create destroy], shallow: true
+    member do
+      resources :community_post_likes, only: %i[create destroy], shallow: true
+    end
+  end
 
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'

--- a/db/migrate/20240210154554_create_community_post_comments.rb
+++ b/db/migrate/20240210154554_create_community_post_comments.rb
@@ -1,0 +1,11 @@
+class CreateCommunityPostComments < ActiveRecord::Migration[7.0]
+  def change
+    create_table :community_post_comments do |t|
+      t.text :message, null: false
+      t.references :user, null: false, foreign_key: true
+      t.references :community_post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240210154748_create_community_post_likes.rb
+++ b/db/migrate/20240210154748_create_community_post_likes.rb
@@ -1,0 +1,10 @@
+class CreateCommunityPostLikes < ActiveRecord::Migration[7.0]
+  def change
+    create_table :community_post_likes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :community_post, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_02_05_134247) do
+ActiveRecord::Schema[7.0].define(version: 2024_02_10_154748) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -21,6 +21,25 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_05_134247) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "community_post_comments", force: :cascade do |t|
+    t.text "message", null: false
+    t.bigint "user_id", null: false
+    t.bigint "community_post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["community_post_id"], name: "index_community_post_comments_on_community_post_id"
+    t.index ["user_id"], name: "index_community_post_comments_on_user_id"
+  end
+
+  create_table "community_post_likes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "community_post_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["community_post_id"], name: "index_community_post_likes_on_community_post_id"
+    t.index ["user_id"], name: "index_community_post_likes_on_user_id"
   end
 
   create_table "community_posts", force: :cascade do |t|
@@ -108,6 +127,10 @@ ActiveRecord::Schema[7.0].define(version: 2024_02_05_134247) do
     t.integer "non_drinking_days", default: [], array: true
   end
 
+  add_foreign_key "community_post_comments", "community_posts"
+  add_foreign_key "community_post_comments", "users"
+  add_foreign_key "community_post_likes", "community_posts"
+  add_foreign_key "community_post_likes", "users"
   add_foreign_key "community_posts", "users"
   add_foreign_key "drink_records", "users"
   add_foreign_key "groups", "users", column: "group_admin_id"

--- a/spec/factories/community_post_comments.rb
+++ b/spec/factories/community_post_comments.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :community_post_comment do
+    message { "MyText" }
+    user { nil }
+    post { nil }
+  end
+end

--- a/spec/factories/community_post_likes.rb
+++ b/spec/factories/community_post_likes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :community_post_like do
+    user { nil }
+    post { nil }
+  end
+end

--- a/spec/helpers/community_post_comments_helper_spec.rb
+++ b/spec/helpers/community_post_comments_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommunityPostCommentsHelper. For example:
+#
+# describe CommunityPostCommentsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommunityPostCommentsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/community_post_likes_helper_spec.rb
+++ b/spec/helpers/community_post_likes_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the CommunityPostLikesHelper. For example:
+#
+# describe CommunityPostLikesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe CommunityPostLikesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/community_post_comment_spec.rb
+++ b/spec/models/community_post_comment_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CommunityPostComment, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/community_post_like_spec.rb
+++ b/spec/models/community_post_like_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe CommunityPostLike, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/community_post_comments_spec.rb
+++ b/spec/requests/community_post_comments_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "CommunityPostComments", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/community_post_comments/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/community_post_comments/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/community_post_likes_spec.rb
+++ b/spec/requests/community_post_likes_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "CommunityPostLikes", type: :request do
+  describe "GET /create" do
+    it "returns http success" do
+      get "/community_post_likes/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/community_post_likes/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/community_post_comments/create.html.erb_spec.rb
+++ b/spec/views/community_post_comments/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_post_comments/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_post_comments/destroy.html.erb_spec.rb
+++ b/spec/views/community_post_comments/destroy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_post_comments/destroy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_post_likes/create.html.erb_spec.rb
+++ b/spec/views/community_post_likes/create.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_post_likes/create.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/community_post_likes/destroy.html.erb_spec.rb
+++ b/spec/views/community_post_likes/destroy.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "community_post_likes/destroy.html.erb", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
- コミュニティポストに対するコメント・いいね機能を追加しました。
## 確認方法
- コミュニティポストの詳細ページにコメント欄が追加されていることを確認してください。
- 投稿されたコメントがコメントフォームの下部に表示されることを確認してください。
- 投稿されたコミュニティポストの「いいね」クリックすることで、いいね数が増減することを確認してください。
## 影響範囲
- 新たに`CommunityPostLike`モデルと`CommunityPostComment`モデルを追加し、Userモデルにおいてアソシエーションの追加、メソッドの追加をしています。