### PR TITLE
Add:グラフ表示の追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
 
   def default_og
     {
-      site: '肝ログ 〜LiverLog〜',
+      site_name: '肝ログ 〜LiverLog〜',
       title: :title,
       description: '『肝ログ』は、休肝日と飲酒日を記録することで、飲酒管理ができるサービスです。
       ついつい飲み過ぎてしまう方、適度に飲酒したい方などご自分の飲酒について見直すきっかけになるアプリです！ぜひご活用ください🍻',

--- a/app/views/profiles/_chart.html.erb
+++ b/app/views/profiles/_chart.html.erb
@@ -28,6 +28,22 @@
           backgroundColor: "rgba(255, 99, 132, 0.2)",
           borderColor: "rgb(255, 99, 132)",
           borderWidth: 1
+        },
+        {
+          label: 'リスクが高まる量（女性）',
+          data: [20, 20, 20, 20, 20, 20, 20],
+          type: 'line',
+          fill: false,
+          borderColor: 'rgb(75, 192, 192)',
+          tension: 0.1
+        },
+        {
+          label: 'リスクが高まる量（男性）',
+          data: [40, 40, 40, 40, 40, 40, 40],
+          type: 'line',
+          fill: false,
+          borderColor: 'rgb(255, 205, 86)',
+          tension: 0.1
         }]
       },
       options: {
@@ -40,8 +56,7 @@
         responsive: true,
         scales: {
           y: {
-            suggestedMin: 0,
-            suggestedMax: 10
+            suggestedMax: 50
           },
           x: {
             stacked: true

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -51,6 +51,11 @@
         </div>
         <input type="radio" name="my_tabs_1" role="tab" class="tab custom-tab" aria-label="グラフ"/>
         <div role="tabpanel" class="tab-content mt-4">
+          <div class="alert alert-warning">
+            <p>厚生労働省が推進する国民健康づくり運動「健康日本21」によると、<span class="font-bold">生活習慣病のリスクを高める１日当たりの純アルコール摂取量は</span><span class="font-bold underline text-red-600 text-xl">男性40g以上、女性20g以上</span>であるとされています。(厚生労働省「健康に配慮した飲酒に関するガイドライン」
+            <%= link_to "詳しくはこちら", "https://www.mhlw.go.jp/stf/newpage_37908.html", class: "font-semibold underline" %>)
+            </p>
+          </div>
           <%= render partial: 'profiles/chart', locals: { drink_records: @drink_records } %>
         </div>
         <input type="radio" name="my_tabs_1" role="tab" class="tab custom-tab" aria-label="コミュニティポスト"/>


### PR DESCRIPTION
## 概要
- 厚労省の「飲酒におけるガイドライン」に示されている生活習慣病リスクの高まる純アルコール量をマイページのグラフに表示して、自分の記録した純アルコール量と比較できるようにしました。
## 確認方法
- マイページのグラフにおいてy軸が`40`と`20`のところに線グラフが表示されていることを確認してください。