### PR TITLE
Fix:初回ログイン後のページの修正

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@ class ApplicationController < ActionController::Base
 
   before_action :require_login
   before_action :require_general
+  before_action :require_first_login
 
   rescue_from CanCan::AccessDenied do |_exception|
     redirect_to main_app.root_path, error: '画面を閲覧する権限がありません。'
@@ -19,5 +20,15 @@ class ApplicationController < ActionController::Base
 
     redirect_to group_path(current_user.groups.first),
                 warning: t('defaults.access_denied')
+  end
+
+  def require_first_login
+    return unless current_user.first_login
+
+    if current_user.invitee?
+      redirect_to invitees_invitation_first_login_path
+    else
+      redirect_to first_login_path
+    end
   end
 end

--- a/app/controllers/community_posts_controller.rb
+++ b/app/controllers/community_posts_controller.rb
@@ -1,6 +1,7 @@
 class CommunityPostsController < ApplicationController
   skip_before_action :require_login, only: %i[index]
   skip_before_action :require_general, only: %i[index show]
+  skip_before_action :require_first_login, only: %i[index]
   before_action :set_user, only: %i[index new create edit update destroy]
   before_action :set_community_post, only: %i[show edit update destroy]
 

--- a/app/controllers/invitees/invitation_controller.rb
+++ b/app/controllers/invitees/invitation_controller.rb
@@ -1,6 +1,7 @@
 class Invitees::InvitationController < ApplicationController
-  skip_before_action :require_login, only: %i[new create]
+  skip_before_action :require_login, only: %i[new first_login]
   skip_before_action :require_general, only: %i[new first_login update]
+  skip_before_action :require_first_login, only: %i[new first_login update]
   before_action :group_invite_token, only: %i[new]
   before_action :set_user, only: %i[first_login update]
 
@@ -28,9 +29,9 @@ class Invitees::InvitationController < ApplicationController
   end
 
   def first_login?
-    if !@user.first_login
-      redirect_to group_path(@user.group.first), warning: '既にプロフィールは登録済みです'
-    end
+    return if @user.first_login
+
+    redirect_to group_path(@user.group.first), warning: '既にプロフィールは登録済みです'
   end
 
   def group_invite_token

--- a/app/controllers/invitees/oauths_controller.rb
+++ b/app/controllers/invitees/oauths_controller.rb
@@ -1,6 +1,7 @@
 class Invitees::OauthsController < ApplicationController
   skip_before_action :require_login
   skip_before_action :require_general
+  skip_before_action :require_first_login
 
   def oauth
     session[:invite_token] = params[:invite_token]

--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -1,6 +1,7 @@
 class OauthsController < ApplicationController
   skip_before_action :require_login
   skip_before_action :require_general
+  skip_before_action :require_first_login
 
   def oauth
     login_at(params[:provider])

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,7 @@
 class StaticPagesController < ApplicationController
   skip_before_action :require_login, only: %i[top first_login terms_of_service privacy_policy]
   skip_before_action :require_general, only: %i[top first_login terms_of_service privacy_policy]
+  skip_before_action :require_first_login, only: %i[top first_login terms_of_service privacy_policy update]
   before_action :set_user, only: %i[first_login update]
   before_action :first_login?, only: %i[first_login update]
 
@@ -19,7 +20,7 @@ class StaticPagesController < ApplicationController
       redirect_to profile_path, success: 'プロフィールを登録しました'
     else
       flash.now[:error] = 'プロフィールの登録に失敗しました'
-      render 'first_login'
+      render 'first_login', status: :unprocessable_entity
     end
   end
 

--- a/app/views/invitees/invitation/first_login.html.erb
+++ b/app/views/invitees/invitation/first_login.html.erb
@@ -4,7 +4,7 @@
     <div class="card-body mx-auto items-center text-center">
       <h2 class="card-title"><%= t '.title' %></h2>
       <p><%= t '.form_description' %></p>
-      <%= render partial: 'shared/error_messages', locals: { object: @user } %
+      <%= render partial: 'shared/error_messages', locals: { object: @user } %>
       <%= form_with(model: @user, url: invitees_invitation_first_login_path, local: true) do |f| %>
         <div class="form-control w-full max-w-full py-2">
           <%= f.label :username, class: "label" %>

--- a/app/views/static_pages/first_login.html.erb
+++ b/app/views/static_pages/first_login.html.erb
@@ -4,7 +4,7 @@
     <div class="card-body mx-auto items-center text-center">
       <h2 class="card-title"><%= t '.form_title' %></h2>
       <p><%= t '.form_description' %></p>
-      <%= render partial: 'shared/error_messages', locals: { object: @user } % %>
+      <%= render partial: 'shared/error_messages', locals: { object: @user } %>
       <%= render partial:'shared/form', locals: {user: @user, url: first_login_path} %>
     </div>
   </div>


### PR DESCRIPTION
## 概要
- 初回ログイン後のプロフィール新規登録画面に遷移しない問題を修正しました。
## 確認方法
- 初回ログイン後にプロフィール新規登録画面に遷移することを確認してください。
- 初回にプロフィール新規登録をしていない場合は、新規登録画面にリダイレクトすることを確認してください。