### PR TITLE
Add:Xへの共有機能の追加

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,31 +2,24 @@ module ApplicationHelper
   def default_meta_tags
     {
       site: '肝ログ 〜LiverLog〜',
-      reverse: true,
-      separator: '|',
-      og: default_og,
-      twitter: default_twitter
-    }
-  end
-
-  private
-
-  def default_og
-    {
-      site_name: '肝ログ 〜LiverLog〜',
       title: :title,
-      description: '『肝ログ』は、休肝日と飲酒日を記録することで、飲酒管理ができるサービスです。
-      ついつい飲み過ぎてしまう方、適度に飲酒したい方などご自分の飲酒について見直すきっかけになるアプリです！ぜひご活用ください🍻',
+      reverse: true,
+      description: '『肝ログ』は、休肝日と飲酒日を記録することで、飲酒管理ができるサービスです。ついつい飲み過ぎてしまう方、適度に飲酒したい方などご自分の飲酒について見直すきっかけになるアプリです！ぜひご活用ください🍻',
+      keywords: '肝ログ,休肝日,飲酒日,飲酒管理,飲酒記録,飲酒量,飲酒量管理,飲酒量記録,健康に配慮した飲酒に関するガイドライン',
+      canonical: request.original_url,
       separator: '|',
-      url: request.url,
-      image: image_url('apple-touch-icon.png')
-    }
-  end
-
-  def default_twitter
-    {
-      card: 'summary',
-      site: '@liverlog'
+      og: {
+        site_name: :site,
+        title: :title,
+        url: request.original_url,
+        image: image_url('apple-touch-icon.png'),
+        type: 'website',
+        description: :description
+      },
+      twitter: {
+        card: 'summary_large_image',
+        site: '@liverlog'
+      }
     }
   end
 end

--- a/app/helpers/drink_records_helper.rb
+++ b/app/helpers/drink_records_helper.rb
@@ -1,6 +1,30 @@
 module DrinkRecordsHelper
   def alcohol_caluculate(volume = 0, percentage = 0)
     return 0 unless volume && percentage
+
     (volume.to_f * (percentage.to_f * 0.01) * 0.8).round(2)
+  end
+
+  def tweet_record(drink_record_details)
+    if drink_record_details.first.record_type == 'no_drink'
+      "#{drink_record_details.first.user.username}さんが休肝日を達成しました！！（#{drink_record_details.first.start_time.strftime('%m月%d日')})\n"
+    else
+      alert_message(drink_record_details)
+    end
+  end
+
+  private
+
+  def alert_message(drink_record_details)
+    text = "#{drink_record_details.first.user.username}さんがお酒を嗜みました🍺（#{drink_record_details.first.start_time.strftime('%m月%d日')}の純アルコール量：#{drink_record_details.alcohol_caluculate}g)%0a"
+    if drink_record_details.alcohol_caluculate >= 40
+      text += '生活習慣病リスクが高まる可能性がある純アルコール量を超えています。明らかに飲み過ぎです😠'
+      text
+    elsif drink_record_details.alcohol_caluculate >= 20
+      text += '生活習慣病リスクが高まる可能性がある純アルコール量を超えています。飲み過ぎには注意しましょう！'
+      text
+    else
+      text
+    end
   end
 end

--- a/app/views/drink_records/show.html.erb
+++ b/app/views/drink_records/show.html.erb
@@ -21,6 +21,10 @@
     </div>
     <% if @drink_record.user == current_user %>
       <div class="card-actions justify-end mx-8 mb-4">
+        <p class="block text-center my-auto">シェア</p>
+        <%= link_to "https://twitter.com/intent/tweet?text=#{tweet_record(@drink_record_details)}%0a%0a&url=https://liverlog-bff5ca6e49ba.herokuapp.com%0a%0a&hashtags=肝ログ&hashtags=飲酒記録", class: "block text-center my-auto pr-2", target: "_blank", rel: "noopener noreferrer", title: "Xでシェア" do %> 
+          <i class="fa-brands fa-x-twitter fa-2xl"></i>
+        <% end %>
         <% if @drink_record.drink? %>
           <%= link_to t('defaults.add_record'), new_drink_record_path(record_id: @drink_record.id), class: "btn btn-outline btn-secondary" %>
         <% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -5,6 +5,6 @@ pin '@hotwired/turbo-rails', to: 'turbo.min.js', preload: true
 pin '@hotwired/stimulus', to: 'stimulus.min.js', preload: true
 pin '@hotwired/stimulus-loading', to: 'stimulus-loading.js', preload: true
 pin_all_from 'app/javascript/controllers', under: 'controllers'
-pin '@fortawesome/fontawesome-free', to: 'https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.2.0/js/all.js'
+pin '@fortawesome/fontawesome-free', to: 'https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.5.1/js/all.js'
 pin 'chart.js', to: 'https://ga.jspm.io/npm:chart.js@4.4.1/dist/chart.js'
 pin '@kurkle/color', to: 'https://ga.jspm.io/npm:@kurkle/color@0.3.2/dist/color.esm.js'


### PR DESCRIPTION
## 概要
- 休肝日&飲酒記録をXに共有できるようにしました。
## 確認方法
- 記録詳細ページから「X」の共有ボタンが表示されていることを確認してください。
- 共有ボタンから「X」の新規ポスト作成画面に遷移することを確認してください。その際にあらかじめ設定してある本文とURLとハッシュタグが投稿画面に表示されていることを確認してください。
## コメント
- 今後はコミュニティページにもポストできるように設定します。