### PR TITLE
Fix:DrinkRecordの関連付けの修正

### DIFF
--- a/app/models/drink_record.rb
+++ b/app/models/drink_record.rb
@@ -1,6 +1,6 @@
 class DrinkRecord < ApplicationRecord
   belongs_to :user
-  has_one :post, dependent: :destroy
+  has_many :posts, dependent: :destroy
 
   validates :start_time, presence: true, uniqueness: { scope: :user_id, message: '：同じ日に休肝日を複数記録することはできません' },
                          if: :record_type_is_no_drink?


### PR DESCRIPTION
## 概要
- DrinkRecordモデルとPostモデルの関連付けにより、複数グループに所属する一般ユーザーの飲酒記録の削除においてエラーが発生していたので修正しました。
## 確認方法
- 複数グループに所属している場合でも記録を削除できることを確認してください。